### PR TITLE
Bugfixes alignment and diffent cluster config support

### DIFF
--- a/tasks/alignment.wdl
+++ b/tasks/alignment.wdl
@@ -5,10 +5,10 @@ import "../structs.wdl" as structs
 
 task bwaAlignBam {
     input {
-        File inputUnalignedBam
-        Int? memoryGb = "16"
+        File inputUnalignedBam  
+        Int? memoryGb = if coordinateSort then "21" else "16"
         #mainly ~4g mergeBamAlignment memory for sorting and ~8 for bwa...
-        Int javaMemoryMb = ceil((memoryGb-8) * 1024 * 0.9)
+        Int javaMemoryMb = ceil((memoryGb-8) * 1024 * 0.95)
 	    String bwaModule = "BWA/0.7.17-GCCcore-11.3.0"
         String picardModule = "picard/2.26.10-Java-8-LTS"
         BwaIndex referenceBwaIndex

--- a/tests/run_project.sh
+++ b/tests/run_project.sh
@@ -6,8 +6,9 @@
 #smart defaults
 PIPELINE="Bestie.wdl"
 WORKFLOWROOT="$PWD"
+CONFIG=$(ls $WORKFLOWROOT/site/*/cromwell.conf) 
 
-while getopts i:s:w:r:f:d:p: flag
+while getopts i:s:w:r:f:d:p:c: flag
 do
     case "${flag}" in
         i) INPUTJSON=${OPTARG};;
@@ -17,6 +18,7 @@ do
         f) FASTQRAWDIRS=${OPTARG};;
         d) DATADIR=${OPTARG};;
         p) PIPELINE=${OPTARG};;
+        c) CONFIG=${OPTARG};;
     esac
 done
 
@@ -72,16 +74,16 @@ ml purge
     #fix samplejson link?
     #ls -alh $RUNROOT
     perl -i.bak -wpe 's?.sampleJson": ".*",?.sampleJson": "'$RUNROOT/sample.json'",?g' $RUNROOT/inputs.json
+
     #start workflow
-    
-    ml cromwell/79-Java-11 
+    ml cromwell/79-Java-11|| ml cromwell 
     set -x
-    java -Xmx8g -Dconfig.file=$WORKFLOWROOT/site/gearshift/cromwell.conf \
+    java -Xmx8g -Dconfig.file=$CONFIG \
         -jar $EBROOTCROMWELL/womtool.jar validate \
         $WORKFLOWROOT/$PIPELINE \
         -i $RUNROOT/inputs.json 
     cd $RUNROOT
-    nohup java -Xmx8g -Dconfig.file=$WORKFLOWROOT/site/gearshift/cromwell.conf \
+    nohup java -Xmx8g -Dconfig.file=$CONFIG \
         -jar $EBROOTCROMWELL/cromwell.jar run \
         $WORKFLOWROOT/$PIPELINE \
         -i $RUNROOT/inputs.json \


### PR DESCRIPTION
Bugfixes

 - tasks/alignment.wdl
    -  sorted mergebamAlignment went out of mem + 5 more memory seems to work
 - tests/run_project.sh
    - added -c option to support different cluster configs current command to get the workflow started:
   
 ```sh
 ./tests/run_project.sh \
   -i $PWD/tests/integration/json/fastqToVariants/inputs_local_twist_umi.json \
   -s ./sample.json \
   -w $PWD \
   -r /path/to/exection/folder/ \
   -f /path/to/fastq/data/folder/,/path/to/fastq/data/folder2/ \
   -d /path/to/data/containing/folder/
   ```