### PR TITLE
Splitting callers into separate workflows

### DIFF
--- a/structs.wdl
+++ b/structs.wdl
@@ -63,6 +63,8 @@ struct SampleDescriptor {
 
 struct SampleConfig {
     Array[SampleDescriptor] samples
+    IndexedFile? genomicVariants
+    IndexedFile? somaticVariants
 }
 #wip maybe in future analysis workflows 
 struct TumorNormalSampleConfig {

--- a/tasks/bcftools.wdl
+++ b/tasks/bcftools.wdl
@@ -14,7 +14,7 @@ task Index {
 
     }
     command {
-        set -e
+        set -e -o pipefail
         #cp ~{inputVcf} ./
         module load ~{bcftoolsModule} && \
         bcftools index -t ~{inputVcf}
@@ -45,12 +45,10 @@ task Norm {
         Int memoryGb = "1"
         String bcftoolsModule = "BCFtools/1.21-GCC-12.2.0"
         Int timeMinutes = 1 + ceil(size(inputVcf, "G")) * 120
-        #Possible values: {unsorted, queryname, coordinate, duplicate, unknown} #
         Int disk = 1 + ceil(size(inputVcf, "G")) * 1024
-
     }
     command {
-        set -e
+        set -e -o pipefail
         #cp ~{inputVcf} ./
         module load ~{bcftoolsModule} && \
         bcftools norm \
@@ -101,7 +99,7 @@ task ViewSamples {
         bcftools view \
             --samples ~{sep=',' samples} \
             ~{inputVcf} | \
-        perl -wpe 's/\t\.:\.(:\.)+/\t./ if m/\t\.:\.(:\.)+[\t\n]/' | \
+        perl -wpe 's/\t\.:\.(:\.)+/\t./ if m/\t\.:\.(:\.|:[ATCG]+)+[\t\n]/' | \
         bgzip -c > ~{outputBasename}".vcf.gz"
         tabix -p vcf  ~{outputBasename}".vcf.gz"
     }
@@ -110,6 +108,10 @@ task ViewSamples {
         File vcf = outputBasename + ".vcf.gz"
         File vcfIdx = vcf + ".tbi"
         IndexedFile vcfOut = {
+          "file" : vcf,
+          "index" : vcfIdx
+        }
+        IndexedFile idxVcf = {
           "file" : vcf,
           "index" : vcfIdx
         }
@@ -123,15 +125,18 @@ task ViewSamples {
 }
 
 task Isec {
+    #bcftools isec with the twist that it spits out a really
+    # basic but bcftools compatible vcf file for more tooling options 
     input {
-        Array [File] inputVcfsFiles
-        Array [IndexedFile] inputVcfs
+        Array [File] inputVcfs
+        Array [IndexedFile] inputIdxVcfs
         String outputBasename
         Int memoryGb = "1"
         String bcftoolsModule = "BCFtools/1.21-GCC-12.2.0"
-        Int timeMinutes = 1 + ceil(size(inputVcfsFiles, "G")) * 120
+        Int timeMinutes = 1 + ceil(size(inputVcfs, "G")) * 120
         #Possible values: {unsorted, queryname, coordinate, duplicate, unknown} #
-        Int disk = 1 + ceil(size(inputVcfsFiles, "G")) * 1024
+        Int disk = 1 + ceil(size(inputVcfs, "G")) * 1024
+        Int minIntersect = 1
 
     }
     #This outputs an isec specific table
@@ -148,19 +153,109 @@ task Isec {
     #to (omitting the BINARYPRESENCE_TABLE column for now)
     ##CHROM  POS     ID      REF     ALT     QUAL    FILTER  INFO
     command <<<
-        set -e
-        module load ~{bcftoolsModule} && \
-        bcftools isec \
-            -c all --nfiles +1 \
-            --output /dev/stdout \
-            ~{sep=' ' inputVcfsFiles} | \
-            python3 -c "import sys; print('##fileformat=VCFv4.2\n'+ \
-            '#CHROM\tPOS\tID\tREF\tALT\tQUAL\tFILTER\tINFO'); \
-            [print('\t'.join([fields[0],fields[1],'.',fields[2],fields[3],'.','.','.'])) for line in sys.stdin if (fields:=line.rstrip('\n').split('\t'))]"| \
-            bgzip -c > ~{outputBasename}.vcf.gz
-        tabix -p vcf ~{outputBasename}.vcf.gz
+        set -e -o pipefail
+        module load ~{bcftoolsModule} 
+        NFILES=$(ls ~{sep=' 'inputVcfs} | wc -l )
+        if [ $NFILES -ge 2 ] && \
+            [ $(gzip -qdc ~{sep=' 'inputVcfs} | head -n 10000 | grep -cv '^#') -gt 0 ]; then
+
+            bcftools isec \
+                -c all --nfiles +~{minIntersect} \
+                --output /dev/stdout \
+                ~{sep=' ' inputVcfs} | \
+                python3 -c "import sys; print('##fileformat=VCFv4.2\n'+ \
+                '#CHROM\tPOS\tID\tREF\tALT\tQUAL\tFILTER\tINFO'); \
+                [print('\t'.join([fields[0],fields[1],'.',fields[2],fields[3],'.','.','.'])) for line in sys.stdin if (fields:=line.rstrip('\n').split('\t'))]"| \
+                bgzip -c > ~{outputBasename}.vcf.gz
+            tabix -p vcf ~{outputBasename}.vcf.gz
+
+        else
+            module load ~{bcftoolsModule} 
+
+            cat ~{sep=' ' inputVcfs} >  ~{outputBasename}.vcf.gz
+            tabix -p vcf ~{outputBasename}.vcf.gz
+        fi
     >>>
     
+
+    output {
+        File vcf = outputBasename + ".vcf.gz"
+        File vcfIdx = vcf + ".tbi"
+        IndexedFile vcfOut = {
+          "file" : vcf,
+          "index" : vcfIdx
+        }
+        IndexedFile idxVcf = {
+          "file" : vcf,
+          "index" : vcfIdx
+        }
+    }
+
+    runtime {
+        memory: select_first([memoryGb * 1024,1024])
+        timeMinutes: timeMinutes
+        disk: disk
+    }
+}
+
+task Concat {
+    input {
+        Array [File] inputVcfs
+        Array [IndexedFile] inputIndexedVcfs
+        String outputBasename
+        Int memoryGb = "1"
+        String bcftoolsModule = "BCFtools/1.21-GCC-12.2.0"
+        Int timeMinutes = 1 + ceil(size(inputVcfs, "G")) * 120
+        #Possible values: {unsorted, queryname, coordinate, duplicate, unknown} #
+        Int disk = 1 + ceil(size(inputVcfs, "G")) * 1024
+
+    }
+    command {
+        set -e -o pipefail
+
+        >&2 echo " ## "$(date)" ## Localising files"
+        #finds both files and links due to how the linking system can work. 
+        /usr/bin/find ../inputs/* -type l -o -type f | \
+            (while read FILE; do 
+                if [ ! -e "$TMPDIR/""$(basename "$FILE")" ]; then
+                    cp "$FILE" "$TMPDIR/"
+                    if [[ $FILE =~ \.vcf.gz$ ]]; then
+                        echo "$TMPDIR/""$(basename "$FILE")">>"./vcfs_inputs.list" 
+                    fi
+                else
+                    echo "Duplicate file basename spotted $FILE" && exit 1 
+                fi
+            done )
+        >&2 echo " ## "$(date)" ## Loading modules" 
+        module load ~{bcftoolsModule}
+        
+        >&2 echo " ## "$(date)" ## Running bcftools " 
+
+        #the perl  removes .:.:.:.:.:.:.:.:. bs in the sample descriptions
+        #ls  "~{sep="\" \"" inputVcfs}"
+        #this catches the single scatter interval segfault of bcftools 
+        if [ "$(wc -l "./vcfs_inputs.list" )" -eq 2 ]; then
+            (cat "./vcfs_inputs.list")  | \
+            (
+                while read FILE; do 
+                    if [[ $FILE =~ \.vcf.gz$ ]]; then
+                        cp "$FILE" ~{outputBasename}".vcf.gz"
+                        cp  "$FILE"".tbi"  ~{outputBasename}".vcf.gz.tbi"
+                    fi
+                done
+            )
+        else 
+        
+            bcftools concat \
+            --allow-overlaps \
+            --rm-dups exact \
+            $(cat ./vcfs_inputs.list) | \
+            perl -wpe 's/\t\.:\.(:\.)+/\t./ if m/\t\.:\.(:\.)+[\t\n]/' | \
+            bgzip -c > ~{outputBasename}".vcf.gz"
+            tabix -p vcf  ~{outputBasename}".vcf.gz"
+
+        fi
+    }
 
     output {
         File vcf = outputBasename + ".vcf.gz"
@@ -177,27 +272,102 @@ task Isec {
         disk: disk
     }
 }
-
-task Concat {
+#task GtCheck {
+#
+#}
+task Stats {
     input {
         Array [File] inputVcfs
-        Array [IndexedFile] inputVcfsIndexed
+        Array [IndexedFile] inputIndexedVcfs
         String outputBasename
         Int memoryGb = "1"
         String bcftoolsModule = "BCFtools/1.21-GCC-12.2.0"
-        Int timeMinutes = 1 + ceil(size(inputVcf, "G")) * 120
+        Int timeMinutes = 1 + ceil(size(inputVcfs, "G")) * 120
         #Possible values: {unsorted, queryname, coordinate, duplicate, unknown} #
-        Int disk = 1 + ceil(size(inputVcf, "G")) * 1024
+        Int disk = 1 + ceil(size(inputVcfs, "G")) * 1024
 
     }
     command {
-        set -eo pipefail
-        #the perl  removes .:.:.:.:.:.:.:.:. bs in the sample descriptions
-        module load ~{bcftoolsModule} && \
-        bcftools concat \
-         --allow-overlaps \
-         --rm-dups exact \
-         "~{sep="\" \\\n\"" inputVcfs}" | \
+        set -e 
+        set -o pipefail
+
+        >&2 echo " ## "$(date)" ## Localising files"
+        #finds both files and links due to how the linking system can work. 
+        /usr/bin/find ../inputs/* -type l -o -type f | \
+            (while read FILE; do 
+                if [ ! -e "$TMPDIR/""$(basename "$FILE")" ]; then
+                    cp "$FILE" "$TMPDIR/"
+                    if [[ $FILE =~ \.vcf.gz$ ]]; then
+                        echo "$TMPDIR/""$(basename "$FILE")">>"./vcfs_inputs.list" 
+                    fi
+                else
+                    echo "Duplicate file basename spotted $FILE" && exit 1 
+                fi
+            done )
+        >&2 echo " ## "$(date)" ## Loading modules" 
+        module load ~{bcftoolsModule}
+        
+        >&2 echo " ## "$(date)" ## Running bcftools " 
+
+        #this catches the single scatter interval segfault of bcftools 
+        if [ $(wc -l "./vcfs_inputs.list" ) -eq 2 ]; then
+            for FILE in $(cat "./vcfs_inputs.list"); do
+                if [[ $FILE =~ \.vcf.gz$ ]]; then
+                    bcftools stats $FILE >  ~{outputBasename}".bcftools_stats"
+                fi
+            done
+        else 
+            #this fifo here is to improve multiqc output 
+            # Since it tends to only take a single file with the same output name 
+
+            mkfifo  ~{outputBasename}.tmp.vcf
+
+            bcftools concat \
+            --allow-overlaps \
+            --rm-dups exact \
+            $(cat ./vcfs_inputs.list) >  ~{outputBasename}.tmp.vcf &
+            
+            bcftools stats --af-bins 0.005,0.01,0.02,0.05,0.10,0.20,0.50,0.80,1 ~{outputBasename}.tmp.vcf  > ~{outputBasename}".bcftools_stats"
+
+        fi
+    }
+
+    output {
+        File stats = outputBasename + ".bcftools_stats"
+    }
+
+    runtime {
+        memory: select_first([memoryGb * 1024,1024])
+        timeMinutes: timeMinutes
+        disk: disk
+    }
+}
+
+task Convert {
+    input {
+        IndexedFile inputIndexedVcf
+        Array [String] sampleNames
+        String outputBasename
+        Int memoryGb = "1"
+        String bcftoolsModule = "BCFtools/1.21-GCC-12.2.0"
+        Int timeMinutes = 5 + ceil(size(inputIndexedVcf.file, "G")) * 20
+        #Possible values: {unsorted, queryname, coordinate, duplicate, unknown} #
+        Int disk = 1 + ceil(size(inputIndexedVcf.file, "G")) * 1024
+
+    }
+    command {
+        set -e -o pipefail
+
+        >&2 echo " ## "$(date)" ## Localising files"
+        
+        module load ~{bcftoolsModule}
+        
+        >&2 echo " ## "$(date)" ## Running bcftools " 
+
+       #the --samples doesnt seem to work in convert idk why
+        bcftools convert \
+        --samples '~{sep=',' sampleNames}' \
+        ~{inputIndexedVcf.file} | \
         perl -wpe 's/\t\.:\.(:\.)+/\t./ if m/\t\.:\.(:\.)+[\t\n]/' | \
         bgzip -c > ~{outputBasename}".vcf.gz"
         tabix -p vcf  ~{outputBasename}".vcf.gz"

--- a/tasks/common.wdl
+++ b/tasks/common.wdl
@@ -96,7 +96,7 @@ task UniqueArray {
     }
 
     command {
-        echo -n "~{sep='\n' array}"| sort -u > ./unique.list
+        echo -en "~{sep='\n' array}"| sort -u > ./unique.list
     }
 
     output {
@@ -106,6 +106,37 @@ task UniqueArray {
     runtime {
         memory: memory
         timeMinutes: 20
+    }
+}
+
+task CreateIndexedLink {
+    # Making this of type File will create a link to the copy of the file in
+    # the execution folder, instead of the actual file.
+    # This cannot be propperly call-cached or used within a container.
+    input {
+        File inputFile
+        File indexFile
+        Boolean hardLink = false
+        Int memory = 256
+    }
+
+    command {
+        echo $PWD
+        mkdir -p index/
+        mkdir -p file/
+        ln -t "./file/" -~{if hardLink then "" else "s" }f "$(realpath "~{inputFile}")"  
+        ln -t "./index/" -~{if hardLink then "" else "s" }f "$(realpath "~{indexFile}")"  
+    }
+
+    output {
+        File file = select_first(glob( "./file/*"))
+        File index = select_first(glob( "./index/*"))
+        IndexedFile out = {"file":file,"index":index}
+    }
+
+    runtime {
+        memory: memory
+        timeMinutes: 5
     }
 }
 
@@ -134,7 +165,6 @@ task CreateLink {
         timeMinutes: 5
     }
 }
-
 task CatSampleDescriptorJson {
     # This creates a new sampledescriptor from input sample descriptor later there should be ways to add in files/annotations
     input {
@@ -162,8 +192,9 @@ task AddAlignedReadsToSampleDescriptor {
         Int memory = 256
     }
     command <<<
+        # this either adds alignedreads or replaces them.
         cat ~{write_json(sample)} | \
-            perl -wpe 'BEGIN{our $bam = shift(@ARGV);our $bamidx = shift(@ARGV);};s!"alignedReads":null!"alignedReads":{"file":"$bam","index":"$bamidx"}!g' "~{bam.file}" "~{bam.index}" \
+            perl -wpe 'BEGIN{our $bam = shift(@ARGV);our $bamidx = shift(@ARGV);};s!"alignedReads":null|"alignedReads"\:\{.*?\}!"alignedReads":{"file":"$bam","index":"$bamidx"}!g' "~{bam.file}" "~{bam.index}" \
             > ./sampleJsonUpdated.json  
     >>>
 

--- a/tasks/freebayes.wdl
+++ b/tasks/freebayes.wdl
@@ -13,8 +13,10 @@ task Freebayes {
         File targetIntervalList
         String outputVcfBasename
         String freebayesModule = "freebayes"
-        Int? memoryGb = "4"
-        Int timeMinutes = 1 + ceil(size(inputBams, "G")) * 120
+        Int targetScatter = 1
+        Int? memoryGb = "18"
+        Int timeMinutes = 1 + ceil(size(inputBams, "G")) * 120 / targetScatter 
+        
     }
     String vcfSuffix =  ".vcf.gz"
     #https://github.com/broadinstitute/warp/blob/develop/tasks/broad/BamProcessing.wdl#L96
@@ -38,7 +40,6 @@ task Freebayes {
         grep -v '^@' ~{targetIntervalList} | perl -wlane 'print join("\t",($F[0],$F[1]-1,$F[2],$.));' > targets.bed
         
         
-
         freebayes \
             --fasta-reference ~{reference.fasta} \
             --targets ./targets.bed \
@@ -66,8 +67,9 @@ task FreebayesSomatic {
         File targetIntervalList
         String outputVcfBasename
         String freebayesModule = "freebayes"
-        Int? memoryGb = "24"
-        Int timeMinutes = 1 + ceil(size(inputBams, "G")) * 400
+        Int? memoryGb = "18"
+        Int targetScatter = 1
+        Int timeMinutes = 1 + ceil(size(inputBams, "G")) * 400 /targetScatter
         Int disk = ceil(size(inputBams, "M")*1.2)
     }
     String vcfSuffix =  ".vcf.gz"
@@ -75,10 +77,10 @@ task FreebayesSomatic {
     command <<<
         set -e 
         set -o pipefail
-
+        #idk why but freebayes randomises the vcf output file sample columns.  
         >&2 echo " ## "$(date)" ## Localising files" 
-        cat ~{write_lines(select_all(inputBams))} \
-            ~{write_lines(inputBamIndexes)} | \
+        cat ~{write_lines(inputBams)} \
+            ~{write_lines(inputBamIndexes)} | sort | \
             (while read FILE; do 
                 if [ ! -e "$TMPDIR/""$(basename "$FILE")" ]; then
                     cp "$FILE" "$TMPDIR/"
@@ -103,6 +105,9 @@ task FreebayesSomatic {
         else 
             minAlternateFraction="0.03"
         fi
+
+        #idk why but depending on amount of intervals/reference retrieved 
+        #from remote disk performance may suffer > 10x slowdowns
         
         >&2 echo " ## "$(date)" ## Running freebayes" 
         freebayes \
@@ -121,12 +126,12 @@ task FreebayesSomatic {
             --vcf /dev/stdout \
             --targets ./targets.bed \
             --bam-list ./bams_inputs.list \
-            --use-best-n-alleles 10 \
+            --use-best-n-alleles 5 \
             --limit-coverage 10000 \
-        --haplotype-length -1 | \
+            --haplotype-length -1 | \
         perl -wpe 's/\t\.:\.(:\.)+/\t./ if m/\t\.:\.(:\.)+[\t\n]/' | \
         tee >( perl -wne 'if($.%20 == 0){
-            print "##info##".scalar(localtime)."##".$_ ;}' \
+            print "## info ## ".scalar(localtime)." ## ".$_ ;}' \
                 >> /dev/stderr ) | \
         bgzip -c >  \
             ~{outputVcfBasename}~{vcfSuffix}
@@ -166,9 +171,11 @@ task FreebayesRecall {
         IndexedFile inputVariants
         String outputVcfBasename
         String freebayesModule = "freebayes"
-        Int? memoryGb = "24"
-        Int timeMinutes = 1 + ceil(size(inputBams, "G")) * 400
+        Int? memoryGb = "18"
+        Int targetScatter = 1
+        Int timeMinutes = 5 + ceil(size(inputBams, "G")) * 400 / targetScatter
         Int disk = ceil(size(inputBams, "M")*1.2)
+        
     }
     String vcfSuffix =  ".vcf.gz"
 
@@ -177,7 +184,7 @@ task FreebayesRecall {
         set -o pipefail
 
         >&2 echo " ## "$(date)" ## Localising files" 
-        cat ~{write_lines(select_all(inputBams))} \
+        cat ~{write_lines(inputBams)} \
             ~{write_lines(inputBamIndexes)} | \
             (while read FILE; do 
                 if [ ! -e "$TMPDIR/""$(basename "$FILE")" ]; then
@@ -197,12 +204,18 @@ task FreebayesRecall {
             --fasta-reference ~{reference.fasta} \
             --variant-input ~{inputVariants.file} \
             --only-use-input-alleles \
+            --haplotype-length 0 \
+            --min-alternate-count 1 \
+            --min-alternate-fraction 0 \
+            --no-population-priors \
+            --allele-balance-priors-off \
+            --report-monomorphic \
             --vcf /dev/stdout \
             --bam-list ./bams_inputs.list \
             --limit-coverage 20000 | \
         perl -wpe 's/\t\.:\.(:\.)+/\t./ if m/\t\.:\.(:\.)+[\t\n]/' | \
         tee >( perl -wne 'if($.%20 == 0){
-            print "##info##".scalar(localtime)."##".$_ ;}' \
+            print "## info ## ".scalar(localtime)." ##".$_ ;}' \
                 >> /dev/stderr ) | \
         bgzip -c >  \
             ~{outputVcfBasename}~{vcfSuffix}
@@ -213,7 +226,7 @@ task FreebayesRecall {
 
         tabix -p vcf ~{outputVcfBasename}~{vcfSuffix}
         >&2 echo " ## "$(date)" ## Validating output call lengths"
-        if `grep -c -v '^#' ~{inputVariants.file} ` -ne `grep -c -v '^#' ~{outputVcfBasename}~{vcfSuffix} `; then
+        if [ "$(grep -c -v '^#' ~{inputVariants.file})" -ne "$(grep -c -v '^#' ~{outputVcfBasename}~{vcfSuffix})" ] ; then
             echo "Input and output variant call counts aren't equal. Check '~{inputVariants.file}' and '~{outputVcfBasename}~{vcfSuffix}'." &&  exit 1 
         fi
         >&2 echo " ## "$(date)" ## Done"

--- a/tasks/gatk.wdl
+++ b/tasks/gatk.wdl
@@ -261,7 +261,8 @@ task HaplotypeCallerGVcf {
         Boolean makeBamOut = true
         Boolean useSpanningEventGenotyping = false
         Float? contamination = 0
-        Int timeMinutes = 1 + ceil(size(inputBam.file, "G")) * 120
+        Int targetScatter = 1
+        Int timeMinutes = 1 + ceil(size(inputBam.file, "G")) * 120 / targetScatter
         Int? javaXmxMemoryMb = floor(memoryGb*0.9*1024)
         Int disk = ceil(size(inputBam.file, "M")*1.2)
     }
@@ -305,8 +306,7 @@ task HaplotypeCallerGVcf {
         disk: disk
     }
 }
-
-#add genomicsdb import#
+# add genomicsdb import#
 #--merge-contigs-into-num-partitions 25
 
 task CombineGVCFs {
@@ -465,4 +465,137 @@ task SelectVariants {
 }
 
 #
-  
+task Funcotator {
+    input{
+        IndexedFile inputVcf
+        File inputVcfFile
+        File funcotatorDsTar
+        String outputVcfBasename
+        String vcfSuffix = ".vcf.gz"
+        Reference reference
+        String gatkModule = "GATK"
+        Int memoryGb = "4"
+        Int javaXmxMemoryMb = ceil((memoryGb - 0.5) * 1024)
+        Int timeMinutes = 1 + ceil(size(inputVcfFile, "G")) * 120
+        Int disk = 1 + ceil(size([inputVcfFile,funcotatorDsTar], "G")*1024 * 1.1) #worst case
+    }
+    
+    #Array[File] gvcfs = select_all(inputGVcfs)[]["file"]
+    command <<<
+        ml ~{gatkModule}
+        mkdir -p $TMPDIR/funcotatorDataSource
+        (cd $TMPDIR/funcotatorDataSource && tar -xf ~{funcotatorDsTar})
+
+         gatk --java-options "-Xmx~{javaXmxMemoryMb}m -Xms~{javaXmxMemoryMb}m -XX:GCTimeLimit=50 -XX:GCHeapFreeLimit=10" \
+            Funcotator \
+                --variant ~{inputVcfFile} \
+                --reference  ~{reference.fasta} \
+                --ref-version hg38 \
+                --data-sources-path $TMPDIR/funcotatorDataSource/* \
+                --output ~{outputVcfBasename}~{vcfSuffix} \
+                --output-file-format VCF
+    >>>
+    output {
+        File vcf = outputVcfBasename + vcfSuffix
+        File vcfIdx = outputVcfBasename + vcfSuffix + ".tbi"
+        IndexedFile vcfOut = {
+          "file" : outputVcfBasename + vcfSuffix,
+          "index" : outputVcfBasename + vcfSuffix + ".tbi"
+        }
+    }
+    runtime {
+        memory: select_first([memoryGb * 1024,4*1024])
+        timeMinutes: timeMinutes
+        disk: disk
+    }
+
+}
+
+task HaplotypeCallerRecall {
+    input {
+        #rray[IndexedFile] inputIndexedBam
+        Array[File] inputBams
+        Array[File] inputBais
+        IndexedFile recallIndexedVcf
+        String outputVcfBasename
+        Reference reference
+        String gatkModule = "GATK"
+        Int memoryGb = "12"
+        Int javaMemoryGb = memoryGb - 1
+        Boolean makeGvcf = true
+        Boolean makeBamOut = false
+        Boolean useSpanningEventGenotyping = false
+        Float? contamination = 0
+        Int targetScatter = 1
+        Int timeMinutes = 5 + ceil(size(inputBams, "G")) * 120 / targetScatter
+        Int? javaXmxMemoryMb = floor(memoryGb*0.9*1024)
+        Int disk = ceil(size(inputBams, "M")*1.2)  
+    }
+
+    String vcfSuffix =  if makeGvcf then ".g.vcf.gz" else ".vcf.gz"
+    String bamoutArg =  if makeBamOut then "-bamout " + outputVcfBasename + ".bamout.bam" else ""
+    
+    #https://github.com/broadinstitute/warp/blob/develop/tasks/broad/BamProcessing.wdl#L96
+    command {
+        set -e
+
+         >&2 echo " ## "$(date)" ## Localising files" 
+        cat ~{write_lines(select_all(inputBams))} \
+            ~{write_lines(inputBais)} | \
+            (while read FILE; do 
+                if [ ! -e "$TMPDIR/""$(basename "$FILE")" ]; then
+                    cp "$FILE" "$TMPDIR/"
+                    if [[ $FILE =~ \.bam$ ]]; then
+                        echo "$TMPDIR/""$(basename "$FILE")">>"./bams_inputs.list" 
+                    fi
+                else
+                    echo "Duplicate file basename spotted $FILE" && exit 1 
+                fi
+            done )
+        >&2 echo " ## "$(date)" ## Loading modules" 
+
+        ml ~{gatkModule}
+        gatk --java-options "-Xmx${javaXmxMemoryMb}m -Xms${javaXmxMemoryMb}m -XX:GCTimeLimit=50 -XX:GCHeapFreeLimit=10" \
+            HaplotypeCaller \
+            -R $(realpath ~{reference.fasta}) \
+            $( perl -wpe 'chomp; s/^/ --input /g' ./bams_inputs.list ) \
+            --alleles ~{recallIndexedVcf.file} \
+            --intervals ~{recallIndexedVcf.file} \
+            --force-call-filtered-alleles \
+            --force-active \
+            --create-output-variant-index \
+            --max-assembly-region-size 400 \
+            --max-reads-per-alignment-start 200 \
+            --output "~{outputVcfBasename}~{vcfSuffix}" \
+            -contamination ~{default=0 contamination} \
+            ~{bamoutArg}
+
+        touch ~{outputVcfBasename}.bamout.bam
+    }
+    
+    output {
+        File vcf = outputVcfBasename + vcfSuffix
+        File vcfIdx = outputVcfBasename + vcfSuffix + ".tbi"
+        IndexedFile vcfOut = {
+          "file" : outputVcfBasename + vcfSuffix,
+          "index" : outputVcfBasename + vcfSuffix + ".tbi"
+        }
+        IndexedFile idxVcf = {
+          "file" : outputVcfBasename + vcfSuffix,
+          "index" : outputVcfBasename + vcfSuffix + ".tbi"
+        }
+    }
+
+    runtime {
+        memory: select_first([memoryGb * 1024,4*1024])
+        timeMinutes: timeMinutes
+        disk: disk
+    }
+}
+
+#((ml GATK/4.2.4.1-Java-8-LTS && gatk --java-options "-Xmx4g" HaplotypeCaller -R 
+#$(realpath 949052/Homo_sapiens_assembly38.fasta) --input $(realpath MySampleS2_aligned_reads.bam) \
+# --input $(realpath MySampleS2_aligned_reads.bam) --input $(realpath  MySample ) \
+# --alleles  variants_merged_scat0.vcf.gz --force-call-filtered-alleles \
+# --force-active --create-output-variant-index --max-assembly-region-size 400 \
+# --output test.vcf -L variants_merged_scat0.vcf.gz; ) 

--- a/tasks/gatk_mutect2.wdl
+++ b/tasks/gatk_mutect2.wdl
@@ -31,9 +31,9 @@ task MuTect2JointCalling {
         # it bugs out on ? structs
         #select_all([germlineAfVcf.file,germlineAfVcf.index]),
         #select_all([panelOfNormalsVcf.file,panelOfNormalsVcf.index])
-
+        Int targetScatter = 1
         Int timeMinutes = ceil(10 + size(inputBams,
-            "G")*1.2 ) * 50
+            "G")*1.2 ) * 50 / targetScatter
     }
     
     #IndexedFile controlBam = select_first([inputControlBam,inputBam])

--- a/tasks/lofreq.wdl
+++ b/tasks/lofreq.wdl
@@ -14,15 +14,17 @@ task LoFreqCall {
         String outputVcfBasename
         String lofreqModule = "LoFreq"
         Int? memoryGb = "4"
-        Int timeMinutes = 1 + ceil(size(inputBam, "G")) * 120
+        Int targetScatter = 1
+        Int disk = ceil(size([inputBam,inputBamIndex], "M")*1.2)
+        Int timeMinutes = 5 + ceil(size(inputBam, "G")) * 120 / targetScatter 
     }
     String vcfSuffix =  ".vcf.gz"
     #https://github.com/broadinstitute/warp/blob/develop/tasks/broad/BamProcessing.wdl#L96
     command <<<
-        set -o pipefail
+        set -eo pipefail
         #ordering the files on /tmp
-        cat ~{write_lines(select_all(inputBam))} \
-            ~{write_lines(inputBamIndex)} | \
+        cat ~{write_lines(select_all([inputBam]))} \
+            ~{write_lines(select_all([inputBamIndex]))} | \
             (while read FILE; do 
                 if [ ! -e "$TMPDIR/""$(basename "$FILE")" ]; then
                     cp "$FILE" "$TMPDIR/"
@@ -56,6 +58,7 @@ task LoFreqCall {
     runtime {
         memory: select_first([memoryGb * 1024,4*1024])
         timeMinutes: timeMinutes
+        disk: disk
     }
 }
 task LoFreqSomatic {
@@ -64,20 +67,28 @@ task LoFreqSomatic {
         File inputNormalBamIndex
         File inputTumorBam
         File inputTumorBamIndex
+        String tumorSampleName
+        String normalSampleName
         Reference reference
         File targetIntervalList
         String outputVcfBasename
         String lofreqModule = "LoFreq"
+        String picardModule = "picard"
+        String pipelineUtilModule= "pipeline-util"
+        Int targetScatter = 1
         Int? memoryGb = "4"
-        Int timeMinutes = 1 + ceil(size(inputBam, "G")) * 120
+        Int timeMinutes = 1 + ceil(size([inputNormalBam,inputTumorBam], "G")) * 120 / targetScatter 
+        Int disk = ceil(size([inputNormalBam,inputTumorBam], "M")*1.2)
     }
     String vcfSuffix =  ".vcf.gz"
     #https://github.com/broadinstitute/warp/blob/develop/tasks/broad/BamProcessing.wdl#L96
     command <<<
-        set -o pipefail
+        set -eo pipefail
         #ordering the files on /tmp
+        >&2 echo " ## "$(date)" ## Localising files" 
+
         cat ~{write_lines(select_all([inputTumorBam,inputNormalBam]))} \
-            ~{write_lines([inputNormalBamIndex,inputTumorBamIndex])} | \
+            ~{write_lines(select_all([inputNormalBamIndex,inputTumorBamIndex]))} | \
             (while read FILE; do 
                 if [ ! -e "$TMPDIR/""$(basename "$FILE")" ]; then
                     cp "$FILE" "$TMPDIR/"
@@ -88,50 +99,132 @@ task LoFreqSomatic {
                     echo "Duplicate file basename spotted $FILE" && exit 1 
                 fi
             done )
-        ml ~{lofreqModule}
+        
         #on the fly to bed conversion
         grep -v '^@' ~{targetIntervalList} | perl -wlane 'print join("\t",($F[0],$F[1]-1,$F[2],$.));' > targets.bed
         
+        (
+            ml ~{lofreqModule}
         
+            >&2 echo " ## "$(date)" ## Running lofreq somatic" 
 
-        lofreq somatic \
-            --ref ~{reference.fasta} \
-            --bed ./targets.bed \
-            --call-indels \
-            --outprefix ~{outputVcfBasename} \
-            --normal "$TMPDIR/""$(basename "~{inputBam}")" \
-            --tumor "$TMPDIR/""$(basename "~{inputBam}")" 
+            (  
+                #if no variants found lofreq will report a non zero exit code.
+                lofreq somatic \
+                --ref ~{reference.fasta} \
+                --bed ./targets.bed \
+                --call-indels \
+                --outprefix ~{outputVcfBasename} \
+                --normal "$TMPDIR/""$(basename "~{inputNormalBam}")" \
+                --tumor "$TMPDIR/""$(basename "~{inputTumorBam}")" || \
+                (for extension in tumor_stringent.indels.vcf.gz tumor_stringent.snvs.vcf.gz somatic_final.snvs.vcf.gz somatic_final.indels.vcf.gz; do
+                    touch  ~{outputVcfBasename}${extension}
+                    touch  ~{outputVcfBasename}${extension}.failed
+                done )
+            )
+        )
+        #on the fly to bed conversion
+        (
+            ml ~{pipelineUtilModule}
+
+            >&2 echo " ## "$(date)" ## fixing vcf files" 
+
+
+            #fixup by moving stuff to the genotype fields and adding general fields (AD/GT)
+            for extension in tumor_stringent.indels.vcf.gz tumor_stringent.snvs.vcf.gz somatic_final.snvs.vcf.gz somatic_final.indels.vcf.gz; do
+                OUTVCF="~{outputVcfBasename}""$(basename "${extension}" .vcf.gz)"".fixed.vcf.gz"
+                if [ $(grep -c '^#' ~{outputVcfBasename}${extension} ) -eq 0 ]; then 
+                    cat << EOF | bgzip -c >  ~{outputVcfBasename}$(basename ${extension} .vcf.gz).fixed.vcf.gz
+##fileformat=VCFv4.0
+##fileDate=20250715
+##source=lofreq call -d 101000 -f /groups/umcg-pmb/tmp02/projects/hematopathology/users/umcg-mterpstra/git/Bestie/tests/runs/bamToVariants/cromwell-executions/BamsToVariants/b30f4eea-cde4-444e-93e9-e45dd9ad6f55/call-ScatterAt117_17/shard-0/ScatterAt117_17/034d5aa4-5a46-46ee-81f9-63cb02e75ab8/call-ScatterAt132_21/shard-0/ScatterAt132_21/6b4fb6d9-b76f-4bec-9458-0dfdc3117ac7/call-loFreqSomaticScat/shard-1/inputs/-1706296754/ref.fasta --verbose --no-default-filter -b 1 -l ./targets.bed --call-indels -a 0.010000 -C 7 -s -S lofreq_sample_MySampleS2_norm_MySample_scat0normal_stringent.snvs.vcf.gz,lofreq_sample_MySampleS2_norm_MySample_scat0normal_stringent.indels.vcf.gz -o lofreq_sample_MySampleS2_norm_MySample_scat0tumor_relaxed.vcf.gz /groups/umcg-pmb/tmp02/projects/hematopathology/users/umcg-mterpstra/git/Bestie/tests/runs/bamToVariants/cromwell-executions/BamsToVariants/b30f4eea-cde4-444e-93e9-e45dd9ad6f55/call-ScatterAt117_17/shard-0/ScatterAt117_17/034d5aa4-5a46-46ee-81f9-63cb02e75ab8/call-ScatterAt132_21/shard-0/Sca 
+##reference=/groups/umcg-pmb/tmp02/projects/hematopathology/users/umcg-mterpstra/git/Bestie/tests/runs/bamToVariants/cromwell-executions/BamsToVariants/b30f4eea-cde4-444e-93e9-e45dd9ad6f55/call-ScatterAt117_17/shard-0/ScatterAt117_17/034d5aa4-5a46-46ee-81f9-63cb02e75ab8/call-ScatterAt132_21/shard-0/ScatterAt132_21/6b4fb6d9-b76f-4bec-9458-0dfdc3117ac7/call-loFreqSomaticScat/shard-1/inputs/-1706296754/ref.fasta
+##INFO=<ID=DP,Number=1,Type=Integer,Description="Raw Depth">
+##INFO=<ID=AF,Number=1,Type=Float,Description="Allele Frequency">
+##INFO=<ID=SB,Number=1,Type=Integer,Description="Phred-scaled strand bias at this position">
+##INFO=<ID=DP4,Number=4,Type=Integer,Description="Counts for ref-forward bases, ref-reverse, alt-forward and alt-reverse bases">
+##INFO=<ID=INDEL,Number=0,Type=Flag,Description="Indicates that the variant is an INDEL.">
+##INFO=<ID=CONSVAR,Number=0,Type=Flag,Description="Indicates that the variant is a consensus variant (as opposed to a low frequency variant).">
+##INFO=<ID=HRUN,Number=1,Type=Integer,Description="Homopolymer length to the right of report indel position">
+##FILTER=<ID=min_dp_7,Description="Minimum Coverage 7">
+##FILTER=<ID=max_dp_100000,Description="Maximum Coverage 100000">
+##FILTER=<ID=sb_fdr,Description="Strand-Bias Multiple Testing Correction: fdr corr. pvalue > 0.001000">
+##FILTER=<ID=indelqual_bonf,Description="Indel Quality Multiple Testing Correction: bonf corr. pvalue < 0.010000">
+#CHROM	POS	ID	REF	ALT	QUAL	FILTER	INFO	FORMAT	~{tumorSampleName}	~{normalSampleName}
+EOF
+                else
+                    #This converts the lofreq output to a cleaner formatted vcf file with the tumor sample speficic data in the info fields
+                    #This also adds in the normalsample as a filler for completeness.  
+                    perl -wpe 's/^##fileformat=VCFv4\.0$/##fileformat=VCFv4.2/;
+                        if($_ =~ /^#CHROM/){
+                            print "##INFO=<ID=GT,Number=1,Type=String,Description=\"Genotype\">\n";
+                            print "##INFO=<ID=AD,Number=2,Type=Integer,Description=\"Allelic depths for the ref and alt alleles in the order listed\">\n";
+                            print "##INFO=<ID=UNIQ,Number=0,Type=Flag,Description=\"Unique, i.e. not detectable in paired sample\">\n##INFO=<ID=UQ,Number=1,Type=Integer,Description=\"Phred-scaled uniq score at this position\">\n";
+                            print "##INFO=<ID=SOMATIC,Number=0,Type=Flag,Description=\"Somatic event\">\n";
+                        }
+                        if(m/DP4=(\d+(,\d+){3})(;|\n)/){
+                            my @dp4=split(",",$1);
+                            $_=substr($_,0,-1).";AD=".($dp4[0]+$dp4[1]).",".($dp4[2]+$dp4[3])."\n";
+                            if($dp4[0]+$dp4[1]> 0){
+                                $_=substr($_,0,-1).";GT=0/1\n";
+                            }else{
+                                $_=substr($_,0,-1).";GT=1/1\n";
+                            }
+                        };' <(bgzip -dc ~{outputVcfBasename}${extension} ) > ~{outputVcfBasename}$(basename ${extension} .vcf.gz).tmp.fixed.vcf
+                    InfoFieldsToGenotypeFields.pl  \
+                    -f 'GT,AD,DP,DP4,AF,SB' \
+                    -g "~{tumorSampleName}" \
+                    -i ~{outputVcfBasename}$(basename ${extension} .vcf.gz).tmp.fixed.vcf | \
+                    perl -wpe 's/~{tumorSampleName}/~{tumorSampleName}\t~{normalSampleName}/ if(m/^#CHROM/); s/\n/\t.\n/ if(m/^[^#]/)' | \
+                    bgzip -c > ~{outputVcfBasename}$(basename ${extension} .vcf.gz).fixed.vcf.gz;
+                fi
+            done
+        )
+        >&2 echo " ## "$(date)" ## picard sorting vcf files" 
+
+        #Merge tumor calls to one VCF 
+        (
+            ml ~{picardModule}
+            java -jar $EBROOTPICARD/picard.jar SortVcf \
+                SD=~{reference.dict} \
+                I=~{outputVcfBasename}tumor_stringent.indels.fixed.vcf.gz I=~{outputVcfBasename}tumor_stringent.snvs.fixed.vcf.gz \
+                O=~{outputVcfBasename}tumor_stringent.fixed.vcf.gz
+        )
+        >&2 echo " ## "$(date)" ## done" 
+
     >>>
     
     output {
-        File vcf = outputVcfBasename + vcfSuffix
-        File vcfIdx = outputVcfBasename + vcfSuffix + ".tbi"
+        File vcf = outputVcfBasename + 'tumor_stringent.fixed' + vcfSuffix
+        File vcfIdx = vcf + ".tbi"
     }
 
     runtime {
         memory: select_first([memoryGb * 1024,4*1024])
         timeMinutes: timeMinutes
+        disk: disk
     }
 }
 task LoFreqViterbi {
     input {
-        File inputBam
-        File inputBamIndex
+        IndexedFile inputBamIndexed
         String outputBasename
         Reference reference
         String lofreqModule = "LoFreq"
-        Int? memoryGb = "4"
-        Int timeMinutes = 1 + ceil(size(inputBam, "G")) * 120
+        String picardModule = "picard"
+        Int? memoryGb = "8"
+        Int timeMinutes = 1 + ceil(size(inputBamIndexed.file, "G")) * 120
+        Int disk = ceil(size(inputBamIndexed.file, "M")*1.2)  
     }
     #https://github.com/broadinstitute/warp/blob/develop/tasks/broad/BamProcessing.wdl#L96
     command <<<
-        set -o pipefail
+        set -eo pipefail
         #ordering the files on /tmp
-        cat ~{write_lines(select_all([inputBam]))} \
-            ~{write_lines([inputBamIndex])} | \
+        cat ~{write_lines(select_all([inputBamIndexed.file]))} \
+            ~{write_lines([inputBamIndexed.index])} | \
             (while read FILE; do 
                 if [ ! -e "$TMPDIR/""$(basename "$FILE")" ]; then
-                    cp "$FILE" "$TMPDIR/"
+                    cp "$(realpath "$FILE")" "$TMPDIR/"
                     if [[ $FILE =~ \.bam$ ]]; then
                         echo "$TMPDIR/""$(basename "$FILE")">>"./bams_inputs.list" 
                     fi
@@ -140,25 +233,136 @@ task LoFreqViterbi {
                 fi
             done )
         ml ~{lofreqModule}
-        #on the fly to bed conversion
-        grep -v '^@' ~{targetIntervalList} | perl -wlane 'print join("\t",($F[0],$F[1]-1,$F[2],$.));' > targets.bed
-        
-        
-
+        if [ ! -e ~{inputBamIndexed.file}.bai ]; then 
+            cp -v "$TMPDIR/""$(basename "~{inputBamIndexed.index}")" "$TMPDIR/""$(basename "~{inputBamIndexed.file}.bai")"
+        fi
         lofreq viterbi \
-            --ref ~{reference.fasta} \
-            "$TMPDIR/""$(basename "~{inputBam}")"
+            --ref "~{reference.fasta}" \
+            "$TMPDIR/""$(basename "~{inputBamIndexed.file}")" \
             --out - | \
-        samtools sort - -T $TMPDIR/aln.sorted -o ~{outputBasename}.bam
+        
+        (
+            ml ~{picardModule} && java -jar $EBROOTPICARD/picard.jar \
+            FixMateInformation \
+            SORT_ORDER=coordinate \
+            I=/dev/stdin O=/dev/stdout \
+        ) | (
+            ml ~{picardModule} && java -jar $EBROOTPICARD/picard.jar \
+            SetNmMdAndUqTags \
+            REFERENCE_SEQUENCE="~{reference.fasta}" \
+            I=/dev/stdin O=~{outputBasename}.bam CREATE_INDEX=true
+        )
+        cp ~{outputBasename}.bai ~{outputBasename}.bam.bai  
+
     >>>
     
     output {
-        File vcf = outputVcfBasename + vcfSuffix
-        File vcfIdx = outputVcfBasename + vcfSuffix + ".tbi"
+        File bam = outputBasename + '.bam'
+        File bai = outputBasename + '.bam.bai'
+        IndexedFile bamOut = { 
+          "file" : outputBasename + '.bam',
+          "index" : outputBasename + ".bam.bai"
+        }
     }
 
     runtime {
         memory: select_first([memoryGb * 1024,4*1024])
         timeMinutes: timeMinutes
+        disk: disk
+    }
+}
+task LoFreqViterbiCached {
+    input {
+        IndexedFile inputBamIndexed
+        String outputBasename
+        Reference reference
+        String lofreqModule = "LoFreq"
+        String picardModule = "picard"
+        Int? memoryGb = "8"
+        Int timeMinutes = 1 + ceil(size(inputBamIndexed.file, "G")) * 120
+        Int disk = ceil(size(inputBamIndexed.file, "M")*1.2)  
+    }
+    #https://github.com/broadinstitute/warp/blob/develop/tasks/broad/BamProcessing.wdl#L96
+    command <<<
+        set -xeo pipefail
+        if [ -e "/groups/umcg-pmb/tmp02/projects/hematopathology/users/umcg-mterpstra/projects/20250724_braf_S6_variant_analysis/lofreq-cache/""$(basename "~{outputBasename}.bam")" ]; then 
+            
+            >&2 echo " ## "$(date)" ## Found cached result copying and skipping" 
+
+
+            cp "/groups/umcg-pmb/tmp02/projects/hematopathology/users/umcg-mterpstra/projects/20250724_braf_S6_variant_analysis/lofreq-cache/""$(basename "~{outputBasename}.bam")" ~{outputBasename}.bam
+            cp "/groups/umcg-pmb/tmp02/projects/hematopathology/users/umcg-mterpstra/projects/20250724_braf_S6_variant_analysis/lofreq-cache/""$(basename "~{outputBasename}.bam")".bai ~{outputBasename}.bam.bai
+            exit 0
+        fi
+        #ordering the files on /tmp
+
+        >&2 echo " ## "$(date)" ## Localising files" 
+
+        cat ~{write_lines(select_all([inputBamIndexed.file]))} \
+            ~{write_lines([inputBamIndexed.index])} | \
+            (while read FILE; do 
+                if [ ! -e "$TMPDIR/""$(basename "$FILE")" ]; then
+                    cp "$FILE" "$TMPDIR/"
+                    if [[ $FILE =~ \.bam$ ]]; then
+                        echo "processing bam file $TMPDIR/""$(basename "$FILE")"
+                        (ml SAMtools && 
+                            samtools view -h $FILE | head -n 200000 > test.sam
+                            samtools view -Shb test.sam >  "$TMPDIR/""$(basename "$FILE")"
+                            samtools index "$TMPDIR/""$(basename "$FILE")"
+                        )
+                        echo "$TMPDIR/""$(basename "$FILE")">>"./bams_inputs.list" 
+                    elif [[ $FILE =~ \.bai$ ]]; then
+                        echo "Skipped bai file $TMPDIR/""$(basename "$FILE")"
+                    else
+                        cp "$FILE" "$TMPDIR/"
+                    fi
+                else
+                    echo "Duplicate file basename spotted $FILE" && exit 1 
+                fi
+            done )
+        >&2 echo " ## "$(date)" ## Loading module" 
+
+        ml ~{lofreqModule}
+        if [ ! -e ~{inputBamIndexed.file}.bai ]; then 
+            cp -v "$TMPDIR/""$(basename "~{inputBamIndexed.index}")" "$TMPDIR/""$(basename "~{inputBamIndexed.file}.bai")"
+        fi
+        >&2 echo " ## "$(date)" ## Running lofreq viterbi and fixing up output" 
+
+        lofreq viterbi \
+            --ref "~{reference.fasta}" \
+            "$TMPDIR/""$(basename "~{inputBamIndexed.file}")" \
+            --out - | \
+        
+        (
+            ml ~{picardModule} && java -jar $EBROOTPICARD/picard.jar \
+            FixMateInformation \
+            SORT_ORDER=coordinate \
+            I=/dev/stdin O=/dev/stdout \
+        ) | (
+            ml ~{picardModule} && java -jar $EBROOTPICARD/picard.jar \
+            SetNmMdAndUqTags \
+            REFERENCE_SEQUENCE="~{reference.fasta}" \
+            I=/dev/stdin O=~{outputBasename}.bam CREATE_INDEX=true
+        )
+        cp ~{outputBasename}.bai ~{outputBasename}.bam.bai
+
+        >&2 echo " ## "$(date)" ## Lofreq viterbi done " 
+
+
+    >>>
+    
+    output {
+        File bam = outputBasename + '.bam'
+        File bai = outputBasename + '.bam.bai'
+        IndexedFile bamOut = { 
+          "file" : outputBasename + '.bam',
+          "index" : outputBasename + ".bam.bai"
+        }
+    }
+
+    runtime {
+        memory: select_first([memoryGb * 1024,4*1024])
+        timeMinutes: timeMinutes
+        disk: disk
     }
 }

--- a/tasks/picard.wdl
+++ b/tasks/picard.wdl
@@ -412,7 +412,7 @@ task SortVcfsIndexed {
         module load ~{picardModule}
         java -Xmx~{javaXmxMemoryMb}m -jar $EBROOTPICARD/picard.jar \
         SortVcf \
-        INPUT= ~{sep=' INPUT= ' inputVcfs} \
+        INPUT=~{sep=' INPUT=' inputVcfs} \
         ~{true="CREATE_INDEX=true " false="" createIndex} \
         OUTPUT=~{outputPrefix}~{vcfSuffix}
 

--- a/tasks/pipeline-util.wdl
+++ b/tasks/pipeline-util.wdl
@@ -50,14 +50,25 @@ task ReannotateVariants {
     command <<<
         set -eo pipefail
         ml ~{pipelineUtilModule}
-        perl $EBROOTPIPELINEMINUTIL/bin/RecoverSampleAnnotationsAfterCombineVariantsByPosWalk.pl \
-            ~{outputBasename}.complex.vcf \
-            ~{combinedVariants.file} \
-            ~{sep=' ' inputVcfsFiles} \
-            |bgzip -c >  ~{outputBasename}~{vcfSuffix}
-        
-        tabix -p vcf ~{outputBasename}~{vcfSuffix}
-
+        if [ $(gzip -qdc  ~{combinedVariants.file} | grep -vc '^#' ) -eq 0 ]; then 
+            if [[ "~{combinedVariants.file}" == *.vcf.gz ]]; then
+                >&2 echo " ## "$(date)" ## Only header file detected with known extension copying input to output" 
+                cp $(realpath ~{combinedVariants.file}) "~{outputBasename}~{vcfSuffix}"
+                cp $(realpath ~{combinedVariants.index}) "~{outputBasename}~{vcfSuffix}.tbi"
+            else
+                >&2 echo " ## "$(date)" ## ERROR: Only header file detected with unknown extension. Exiting" 
+                exit 1 
+            fi
+        else
+            >&2 echo " ## "$(date)" ## Reannotating with older data." 
+            perl $EBROOTPIPELINEMINUTIL/bin/RecoverSampleAnnotationsAfterCombineVariantsByPosWalk.pl \
+                ~{outputBasename}.complex.vcf \
+                ~{combinedVariants.file} \
+                ~{sep=' ' inputVcfsFiles} \
+                |bgzip -c >  ~{outputBasename}~{vcfSuffix}
+            
+            tabix -p vcf ~{outputBasename}~{vcfSuffix}
+        fi
     >>>
     output {
         File vcf = outputBasename + vcfSuffix

--- a/tests/integration/json/bamToVariants/inputs.json
+++ b/tests/integration/json/bamToVariants/inputs.json
@@ -5,6 +5,8 @@
     "BamsToVariants.samtoolsModule": "SAMtools/1.21-GCC-13.3.0",
     "BamsToVariants.bcftoolsModule": "BCFtools/1.21-GCC-13.3.0",
     "BamsToVariants.freebayesModule": "freebayes/1.3.7-gfbf-2024a-R-4.4.2",
+    "BamsToVariants.pipelineUtilModule": "pipeline-util/0.8.21-foss-2024a",
+    "BamsToVariants.lofreqModule": "LoFreq/2.1.5-foss-2024a",
     "BamsToVariants.reference": {
       "fasta": "data/ref/ref.fasta",
       "dict": "data/ref/ref.dict",

--- a/tests/integration/json/bamToVariants/inputs_local_Sureselect.json
+++ b/tests/integration/json/bamToVariants/inputs_local_Sureselect.json
@@ -4,7 +4,7 @@
     "BamsToVariants.gatkModule": "GATK/4.6.0.0-GCCcore-13.3.0-Java-21 R/4.4.2-gfbf-2024a",
     "BamsToVariants.samtoolsModule": "SAMtools/1.21-GCC-13.3.0",
     "BamsToVariants.bcftoolsModule": "BCFtools/1.21-GCC-13.3.0",
-    "BamsToVariants.freebayesModule": "freebayes/1.3.7-gfbf-2024a-R-4.4.2",
+    "BamsToVariants.freebayesModule": "freebayes/1.3.10-gfbf-2024a-R-4.4.2-static R/4.4.2-gfbf-2024a",
     "BamsToVariants.pipelineUtilModule": "pipeline-util/0.8.21-foss-2024a",
     "BamsToVariants.lofreqModule": "LoFreq/2.1.5-foss-2024a",
     "BamsToVariants.reference": {
@@ -36,6 +36,6 @@
           "index": "data/gcp-public-data--broad-references/hg38/v0/1000G_phase1.snps.high_confidence.hg38.vcf.gz.tbi"
         }
       ],
-    "BamsToVariants.targetIntervalList": "data/interval_lists/hg38/test/targets_local.interval_list",
-    "BamsToVariants.targetScatter": 3
+    "BamsToVariants.targetIntervalList": "data/interval_lists/hg38/S31285117_SureSelectV7_Regions_hg38.interval_list",
+    "BamsToVariants.targetScatter": 20
 }

--- a/tests/integration/json/fastqToVariants/inputs_local.json
+++ b/tests/integration/json/fastqToVariants/inputs_local.json
@@ -5,7 +5,7 @@
   "FastqToVariants.multiqcModule": "multiqc/1.22.3-GCCcore-11.3.0",
   "FastqToVariants.bwaModule": "BWA/0.7.17-GCCcore-11.3.0",
   "FastqToVariants.picardModule": "picard/2.26.10-Java-15",
-  "FastqToVariants.gatkModule": "GATK/4.6.0.0-GCCcore-13.3.0-Java-21 R/4.4.2-gfbf-2024a",
+  "FastqToVariants.gatkModule": "GATK/4.3.0.0-GCCcore-11.3.0-Java-11 R/4.2.2-foss-2022a",
   "FastqToVariants.samtoolsModule": "SAMtools/1.21-GCC-13.3.0",
   "FastqToVariants.hmmcopyutilsModule": "hmmcopy_utils/5911bf69f1-GCCcore-13.3.0",
   "FastqToVariants.fgbioModule": "fgbio/2.2.1-Java-8",

--- a/tests/integration/json/fastqToVariants/inputs_local_twist_lpwgs.json
+++ b/tests/integration/json/fastqToVariants/inputs_local_twist_lpwgs.json
@@ -5,7 +5,7 @@
     "FastqToVariants.multiqcModule": "multiqc/1.22.3-GCCcore-11.3.0",
     "FastqToVariants.bwaModule": "BWA/0.7.17-GCCcore-11.3.0",
     "FastqToVariants.picardModule": "picard/2.26.10-Java-15",
-    "FastqToVariants.gatkModule": "GATK/4.6.0.0-GCCcore-13.3.0-Java-21 R/4.4.2-gfbf-2024a",
+    "FastqToVariants.gatkModule": "GATK/4.3.0.0-GCCcore-11.3.0-Java-11 R/4.2.2-foss-2022a",
     "FastqToVariants.samtoolsModule": "SAMtools/1.19.2-GCCcore-11.3.0",
     "FastqToVariants.hmmcopyutilsModule": "hmmcopy_utils/5911bf69f1-GCCcore-13.3.0",
     "FastqToVariants.fgbioModule": "fgbio/2.2.1-Java-8",

--- a/tests/integration/json/fastqToVariants/inputs_local_twist_umi.json
+++ b/tests/integration/json/fastqToVariants/inputs_local_twist_umi.json
@@ -5,7 +5,7 @@
     "FastqToVariants.multiqcModule": "multiqc/1.22.3-GCCcore-11.3.0",
     "FastqToVariants.bwaModule": "BWA/0.7.17-GCCcore-11.3.0",
     "FastqToVariants.picardModule": "picard/2.26.10-Java-15",
-    "FastqToVariants.gatkModule": "GATK/4.6.0.0-GCCcore-13.3.0-Java-21 R/4.4.2-gfbf-2024a",
+    "FastqToVariants.gatkModule": "GATK/4.3.0.0-GCCcore-11.3.0-Java-11 R/4.2.2-foss-2022a",
     "FastqToVariants.samtoolsModule": "SAMtools/1.19.2-GCCcore-11.3.0",
     "FastqToVariants.hmmcopyutilsModule": "hmmcopy_utils/5911bf69f1-GCCcore-13.3.0",
     "FastqToVariants.fgbioModule": "fgbio/2.2.1-Java-8",

--- a/tests/integration/run_variantcalling_local.sh
+++ b/tests/integration/run_variantcalling_local.sh
@@ -6,6 +6,6 @@
         -w $PWD \
         -r $PWD/tests/runs/bamToVariants_local \
         -f $PWD/tests/data/raw/fastq/,$PWD/tests/data/raw/bam/ \
-        -d /groups/umcg-pmb/tmp01//apps \
+        -d /groups/umcg-pmb/tmp02/apps \
         -p workflows/bamsToVariants.wdl
 )

--- a/tests/run_project.sh
+++ b/tests/run_project.sh
@@ -7,8 +7,26 @@
 PIPELINE="Bestie.wdl"
 WORKFLOWROOT="$PWD"
 CONFIG=$(ls $WORKFLOWROOT/site/*/cromwell.conf | head -n 1) 
+TARGETINTERVALS="undef"
+HELP=$(cat << 'EOF'
+$0 usage
 
-while getopts i:s:w:r:f:d:p:c: flag
+Helper to localise the data for starting an analysis and setting the correct cromwell command
+
+-i INPUTJSON Input json from commandline containing the wdl settings needed for running the pipeline
+-s SAMPLEJSON Optional samplejson or else you need to put the sampleconfig in the inputjson
+-w WORKFLOWROOT This is the directory with the Bestie.wdl script in it 
+-r RUNROOT This is the dir where all the rundata gets stored
+    $RUNROOT/cromwell-executions/*/workflowName will store most of the data.
+-f FASTQRAWDIR[,FASTQRAWDIR] One or more directories with fastq analysis data in it
+-d DATADIR the dir that contains the 'data' folder usually '/apps/' 
+-p PIPELINE optional setting to switch 
+-c CONFIG Backend or site config atm supports the nibbler cluster (used for hacking in slurm temp storage support)
+-t TARGETINTERVALS Target sequencing intervals to find and replace in the json specify as an interval_list formatted file
+-h This help message
+EOF
+)
+while getopts i:s:w:r:f:d:p:c:t:h flag
 do
     case "${flag}" in
         i) INPUTJSON=${OPTARG};;
@@ -19,6 +37,9 @@ do
         d) DATADIR=${OPTARG};;
         p) PIPELINE=${OPTARG};;
         c) CONFIG=${OPTARG};;
+        t) TARGETINTERVALS=${OPTARG};;
+        h) (>2 echo "$HELP" && exit 0);;
+        *) (>2 echo "Invalid command" && exit 1);;
     esac
 done
 
@@ -98,8 +119,13 @@ ml purge
     done
     #fix samplejson link?
     #ls -alh $RUNROOT
-    perl -i.bak -wpe 's?.sampleJson": ".*",?.sampleJson": "'$RUNROOT/sample.json'",?g' $RUNROOT/inputs.json
+    perl -i.sample.bak -wpe 's?.sampleJson": ".*",?.sampleJson": "'$RUNROOT/sample.json'",?g' $RUNROOT/inputs.json
 
+    if [ -e $TARGETINTERVALS ] ; then 
+        TARGETINTERVALS="$(realpath "$TARGETINTERVALS")"
+        >&2 echo "## target interval list '$TARGETINTERVALS'"
+        perl -i.targets.bak -wpe 's/.targetIntervalList": ".*",/.targetIntervalList": "'$$TARGETINTERVALS'",/g' $RUNROOT/inputs.json
+    fi
     #start workflow
     ml cromwell/79-Java-11|| ml cromwell
     

--- a/workflows/bamsToGermlineVariants.wdl
+++ b/workflows/bamsToGermlineVariants.wdl
@@ -1,0 +1,101 @@
+version 1.0
+
+import "../structs.wdl" as structs
+import "../tasks/common.wdl" as common
+import "../tasks/gatk.wdl" as gatk
+import "../tasks/gatk_mutect2.wdl" as mutect
+
+workflow BamsToGermlineVariants {
+    input {
+        String gatkModule = "GATK/4.2.4.1-Java-8-LTS"
+        Reference reference
+        File? sampleJson
+        SampleConfig? sampleConfigIn 
+        Array[File] targetIntervals
+    }
+    #This is a toggle to either use the sampleconfig in the input json or as separate file for conveniance 
+    SampleConfig sampleConfig = if (defined(sampleConfigIn)) then select_first([sampleConfigIn]) else read_json(select_first([sampleJson]))
+
+    
+    #Array[IndexedFile] sampleIndexedBams = sampleConfig[].samples.alignedReads
+    scatter (sample in sampleConfig.samples) {
+        IndexedFile sampleIndexedBam = select_first([sample.alignedReads])
+
+        call common.CreateLink as gatherBams {
+            input:
+                inputFile = sampleIndexedBam.file,
+                hardLink = true,
+                outputPath = select_first([sample.name])+ "_aligned_reads.bam",
+        }
+        call common.CreateLink as gatherBais {
+            input:
+                inputFile = sampleIndexedBam.index,
+                hardLink = true,
+                outputPath = select_first([sample.name])+ "_aligned_reads.bai",
+        }
+        if(defined(sample.normal)){
+            String sampleNormals = select_first([sample.normal])
+        }
+        String sampleNames = sample.name
+    }
+
+    #haplotypecaller gvcf mode workflow
+    scatter (sample in sampleConfig.samples) {
+        IndexedFile sampleIndexedBamHc = select_first([sample.alignedReads])
+
+        scatter (scatteredtargetsIdx in range(length(targetIntervals))) {
+        
+            #haplotypecallergvcf
+            call gatk.HaplotypeCallerGVcf as haplotypeCallerGvcf {
+                input:
+                    gatkModule = gatkModule,
+                    reference = reference,
+                    inputBam = sampleIndexedBamHc,
+                    outputVcfBasename = sample.name + ".idx_" + scatteredtargetsIdx,
+                    targetIntervalList = targetIntervals[scatteredtargetsIdx],
+                    targetScatter=length(targetIntervals)
+            }
+        }
+        #CombineGVCFs to create a single sample gvcf
+        call gatk.CombineGVCFs as gatherRegions {
+                input:
+                    gatkModule = gatkModule,
+                    reference = reference,
+                    inputGVcfs = haplotypeCallerGvcf.vcfOut,
+                    inputGVcfsFiles = haplotypeCallerGvcf.vcf,
+                    outputVcfBasename = sample.name + "_hcgvcf",
+        }
+
+    }
+
+    #CombineGVCFs to create a single project gvcf
+    call gatk.CombineGVCFs as gatherHcSamples {
+        input:
+            gatkModule = gatkModule,
+            reference = reference,
+            inputGVcfs = gatherRegions.vcfOut,
+            inputGVcfsFiles = gatherRegions.vcf,
+            outputVcfBasename = "hcgvcf_allsamples",
+    }
+    #genotype gvcf
+    call gatk.GenotypeGVCFs as genotypeHcProjectGvcf {
+        input:
+            gatkModule = gatkModule,
+            reference = reference,
+            inputGVcf = gatherHcSamples.vcfOut,
+            inputGVcfsFile = gatherHcSamples.vcf,
+            outputVcfBasename = "hc_allsamples",
+    }
+
+    output {
+        IndexedFile idxGvcf = gatherHcSamples.vcfOut
+        IndexedFile idxVcf = genotypeHcProjectGvcf.vcfOut
+        #Array[IndexedFile] = 
+        #Array[File] = 
+    }
+
+    meta {
+        author: "MMTerpstra"
+        description: "This is the single samples bams to variants workflow."
+    }  
+}

--- a/workflows/bamsToSomaticFreebayesVariants.wdl
+++ b/workflows/bamsToSomaticFreebayesVariants.wdl
@@ -1,0 +1,192 @@
+version 1.0
+
+import "../structs.wdl" as structs
+import "../tasks/common.wdl" as common
+import "../tasks/trimgalore.wdl" as trimgalore
+import "../tasks/cutadapt.wdl" as cutadapt
+import "../tasks/fastqc.wdl" as fastqc
+import "../tasks/picard.wdl" as picard
+import "../tasks/fgbio.wdl" as fgbio
+import "../tasks/alignment.wdl" as align
+import "../tasks/gatk.wdl" as gatk
+import "../tasks/gatk_mutect2.wdl" as mutect
+import "../tasks/bcftools.wdl" as bcftools
+import "../tasks/freebayes.wdl" as freebayes
+import "../tasks/lofreq.wdl" as lofreq
+import "../tasks/pipeline-util.wdl" as util
+import "../tasks/ichorcna.wdl" as ichorcna
+import "../workflows/qc.wdl" as qc
+import "../workflows/bamsToGermlineVariants.wdl" as bamsToGermlineVariants
+
+
+workflow BamsToSomaticFreebayesVariants {
+    input {
+        #String picardModule = "picard/2.26.10-Java-8-LTS"
+        #String gatkModule = "GATK/4.2.4.1-Java-8-LTS"
+        #String samtoolsModule = "SAMtools/1.15.1-GCC-11.3.0"
+        String bcftoolsModule = "BCFtools/1.21-GCC-12.2.0"
+        String freebayesModule = "freebayes/1.3.7-gfbf-2024a-R-4.4.2"
+        String pipelineUtilModule = "pipeline-util/0.8.20-5-ga0a29bb-foss-2024a"
+        #String lofreqModule = "LoFreq/2.1.5-foss-2024a"
+        Reference reference
+        #IndexedFile dbsnp
+        #IndexedFile cosmic
+        #IndexedFile gnomadOnlyAfVcf
+        #IndexedFile panelOfNormalsVcf
+        #Array[IndexedFile] knownSites
+        #File? funcotatorDsTar
+        #Array[SampleDescriptor] sample
+        File? sampleJson
+        SampleConfig? sampleConfigIn 
+        Array[File] targetIntervals
+    }
+    #This is a toggle to either use the sampleconfig in the input json or as separate file for conveniance 
+    SampleConfig sampleConfig = if (defined(sampleConfigIn)) then select_first([sampleConfigIn]) else read_json(select_first([sampleJson]))
+    
+    #Array[IndexedFile] sampleIndexedBams = sampleConfig[].samples.alignedReads
+    scatter (sample in sampleConfig.samples) {
+        IndexedFile sampleIndexedBam = select_first([sample.alignedReads])
+
+        call common.CreateLink as gatherBams {
+            input:
+                inputFile = sampleIndexedBam.file,
+                hardLink = true,
+                outputPath = select_first([sample.name])+ "_aligned_reads.bam",
+        }
+        call common.CreateLink as gatherBais {
+            input:
+                inputFile = sampleIndexedBam.index,
+                hardLink = true,
+                outputPath = select_first([sample.name])+ "_aligned_reads.bai",
+        }
+        if(defined(sample.normal)){
+            String sampleNormals = select_first([sample.normal])
+        }
+        String sampleNames = sample.name
+    }
+    #Array[String] sampleNames 
+    call common.UniqueArray as uniqueNormals {
+        input:
+            array = select_all(sampleNormals)
+    }
+    #this should be the best way of selecting normal samples 
+    #idk how it goes for wdl validation though
+    #Array[SampleDescriptor] normalSamples = []
+    #this works under the assumtion that at least one sampledescriptor is present for each normal name
+    
+    #better to post filter on normal samples 
+    #scatter (sample in viterbiSample) {
+    #    scatter(normalname in select_all(uniqueNormals.outArray)){
+    #        if (sample.name == normalname){
+    #            Boolean isTumor = false 
+    #        }
+    #    }
+    #    Boolean sampleIsTumor = select_first(flatten([isTumor,[true]]))
+    #    placeholder for dbugging
+    #    call common.UniqueArray as uniqueInputs {
+    #        input:
+    #            array = select_all(flatten([[sampleIsTumor],[isTumor,[true]]]))
+    #    }
+    #    if(sampleIsTumor){
+    #        SampleDescriptor viterbiTumorSampleScat = sample
+    #    }
+    #}
+    #Array[SampleDescriptor] viterbiTumor = select_all(viterbiTumorSampleScat)
+
+    #this might also be a way of solving the upper problem of merging the optional normalMatched samples to a list of normal samples
+    #call common.SelectNormals as selectNormalSamples {
+    #    input:
+    #        normaleNames = select_all(uniqueNormals.outArray),
+    #        samples = sampleConfig.samples
+    #}
+
+    scatter (scatteredtargetsIdx in range(length(targetIntervals))) {
+        
+        call freebayes.FreebayesSomatic as freebayesSomatic {
+            input:
+                freebayesModule = freebayesModule,
+                reference = reference,
+                inputBams = gatherBams.link,
+                inputBamIndexes = gatherBais.link,
+                targetIntervalList = targetIntervals[scatteredtargetsIdx],
+                outputVcfBasename = "freebayes_joint_calls_scat"+scatteredtargetsIdx,
+                targetScatter = length(targetIntervals)
+        }
+        #fixing sample order
+        call bcftools.ViewSamples as fixFreebayesSomatic {
+            input:
+                bcftoolsModule=bcftoolsModule,
+                inputVcf=freebayesSomatic.vcf,
+                samples=sampleNames,
+                outputBasename ='freebayes_joint_calls_samplenames_fixed_scat'+scatteredtargetsIdx,
+        }
+    
+        #freebayes downstream filter for normal sample callings
+        call bcftools.ViewSamples as freebayesNormals {
+            input:
+                bcftoolsModule=bcftoolsModule,
+                inputVcf = fixFreebayesSomatic.vcf,
+                outputBasename = "freebayes_normals_scat_"+scatteredtargetsIdx,
+                samples=uniqueNormals.outArray
+        }
+        call util.AdFilter as freebayesFilterGermline {
+            input:
+                inputVariantsToFilter = fixFreebayesSomatic.vcfOut,
+                inputVcfsFiles=[freebayesNormals.vcf],
+                inputVcfs=[freebayesNormals.vcfOut],
+                outputBasename='freebayes_normals_filt_scat_'+ scatteredtargetsIdx,
+        }
+        #filterfreebayes?
+        call util.Callerise as freebayesScatCallerise {
+            input:
+                pipelineUtilModule=pipelineUtilModule,
+                inputVcf = freebayesFilterGermline.vcf,
+                outputBase = "freebayes_tagged_scat_"+scatteredtargetsIdx,
+                caller="freebayes_"
+        }
+        call bcftools.Norm as normaliseFreeBayes {
+            input:
+                bcftoolsModule=bcftoolsModule,
+                reference=reference,
+                inputVcf=freebayesScatCallerise.vcf,
+                outputBasename="freebayes_norm_scat_"+scatteredtargetsIdx,
+        }
+        #Viewsamples fixes sample order by forcing a sample order to the output samples.
+        call bcftools.ViewSamples as fixNormaliseFreeBayes {
+            input:
+                bcftoolsModule=bcftoolsModule,
+                inputVcf=normaliseFreeBayes.vcf,
+                samples=sampleNames,
+                outputBasename ='freebayes_norm_fixed_scat_'+scatteredtargetsIdx,
+        }
+       
+    }
+    call bcftools.Stats as freebayesRawStats {
+        input:
+            inputVcfs=fixFreebayesSomatic.vcf,
+            inputIndexedVcfs=fixFreebayesSomatic.vcfOut,
+            outputBasename="freebayes_raw",
+            bcftoolsModule=bcftoolsModule,
+    }
+
+    call bcftools.Stats as freebayesFilteredStats {
+        input:
+            inputVcfs=fixNormaliseFreeBayes.vcf,
+            inputIndexedVcfs=fixNormaliseFreeBayes.vcfOut,
+            outputBasename="freebayes_filtered",
+            bcftoolsModule=bcftoolsModule,
+    }
+
+    output {
+        #output files of workflow
+        #needs to be debugged probably
+        Array[File] vcf = fixNormaliseFreeBayes.vcf
+        Array[IndexedFile] idxVcf = fixNormaliseFreeBayes.vcfOut
+        Array[File] bcftoolsStats = [freebayesRawStats.stats,freebayesFilteredStats.stats]
+    }
+
+    meta {
+        author: "MMTerpstra"
+        description: "This is the single samples bams to variants workflow."
+    }  
+}

--- a/workflows/bamsToSomaticLofreqVariants.wdl
+++ b/workflows/bamsToSomaticLofreqVariants.wdl
@@ -1,0 +1,288 @@
+version 1.0
+
+import "../structs.wdl" as structs
+import "../tasks/common.wdl" as common
+import "../tasks/trimgalore.wdl" as trimgalore
+import "../tasks/cutadapt.wdl" as cutadapt
+import "../tasks/fastqc.wdl" as fastqc
+import "../tasks/picard.wdl" as picard
+import "../tasks/fgbio.wdl" as fgbio
+import "../tasks/alignment.wdl" as align
+import "../tasks/gatk.wdl" as gatk
+import "../tasks/gatk_mutect2.wdl" as mutect
+import "../tasks/bcftools.wdl" as bcftools
+import "../tasks/freebayes.wdl" as freebayes
+import "../tasks/lofreq.wdl" as lofreq
+import "../tasks/pipeline-util.wdl" as util
+import "../tasks/ichorcna.wdl" as ichorcna
+import "../workflows/qc.wdl" as qc
+
+workflow BamsToSomaticLofreqVariants {
+    input {
+        String picardModule = "picard/2.26.10-Java-8-LTS"
+        String gatkModule = "GATK/4.2.4.1-Java-8-LTS"
+        String samtoolsModule = "SAMtools/1.15.1-GCC-11.3.0"
+        String bcftoolsModule = "BCFtools/1.21-GCC-12.2.0"
+        #String freebayesModule = "freebayes/1.3.7-gfbf-2024a-R-4.4.2"
+        String pipelineUtilModule = "pipeline-util/0.8.20-5-ga0a29bb-foss-2024a"
+        String lofreqModule = "LoFreq/2.1.5-foss-2024a"
+        Reference reference
+        #IndexedFile dbsnp
+        #IndexedFile cosmic
+        #IndexedFile gnomadOnlyAfVcf
+        #IndexedFile panelOfNormalsVcf
+        #Array[IndexedFile] knownSites
+        #File? funcotatorDsTar
+        #Array[SampleDescriptor] sample
+        File? sampleJson
+        SampleConfig? sampleConfigIn 
+        Array[File] targetIntervals
+    }
+    #This is a toggle to either use the sampleconfig in the input json or as separate file for conveniance 
+    SampleConfig sampleConfig = if (defined(sampleConfigIn)) then select_first([sampleConfigIn]) else read_json(select_first([sampleJson]))
+
+    
+    #Array[IndexedFile] sampleIndexedBams = sampleConfig[].samples.alignedReads
+    scatter (sample in sampleConfig.samples) {
+        IndexedFile sampleIndexedBam = select_first([sample.alignedReads])
+
+        call common.CreateLink as gatherBams {
+            input:
+                inputFile = sampleIndexedBam.file,
+                hardLink = true,
+                outputPath = select_first([sample.name])+ "_aligned_reads.bam",
+        }
+        call common.CreateLink as gatherBais {
+            input:
+                inputFile = sampleIndexedBam.index,
+                hardLink = true,
+                outputPath = select_first([sample.name])+ "_aligned_reads.bai",
+        }
+        if(defined(sample.normal)){
+            String sampleNormals = select_first([sample.normal])
+        }
+        String sampleNames = sample.name
+    }
+    #Array[String] sampleNames 
+    call common.UniqueArray as uniqueNormals {
+        input:
+            array = select_all(sampleNormals)
+    }
+    #this should be the best way of selecting normal samples 
+    #idk how it goes for wdl validation though
+    #Array[SampleDescriptor] normalSamples = []
+    scatter (sample in sampleConfig.samples) {
+        call lofreq.LoFreqViterbiCached as viterbiRealingment {
+            input:
+                inputBamIndexed=select_first([sample.alignedReads]),
+                reference=reference,
+                picardModule=picardModule,
+                lofreqModule=lofreqModule,
+                outputBasename=sample.name + '_viterbi'
+        }
+        
+        call common.AddAlignedReadsToSampleDescriptor as addViterbiBamToSample {
+            input:
+                sample=sample,
+                bam=viterbiRealingment.bamOut
+        }
+        
+        SampleDescriptor viterbiSample = addViterbiBamToSample.sampleUpdated
+    }
+
+    #this works under the assumtion that at least one sampledescriptor is present for each normal name
+    
+    scatter(normalname in select_all(uniqueNormals.outArray)){
+        scatter (sample in viterbiSample) {
+            if (sample.name == normalname){
+                SampleDescriptor viterbiNormalSampleScat = sample
+            }
+        }
+        Array[SampleDescriptor] viterbiNormal = select_all(viterbiNormalSampleScat)
+    }
+    #better to post filter on normal samples 
+    #scatter (sample in viterbiSample) {
+    #    scatter(normalname in select_all(uniqueNormals.outArray)){
+    #        if (sample.name == normalname){
+    #            Boolean isTumor = false 
+    #        }
+    #    }
+    #    Boolean sampleIsTumor = select_first(flatten([isTumor,[true]]))
+    #    placeholder for dbugging
+    #    call common.UniqueArray as uniqueInputs {
+    #        input:
+    #            array = select_all(flatten([[sampleIsTumor],[isTumor,[true]]]))
+    #    }
+    #    if(sampleIsTumor){
+    #        SampleDescriptor viterbiTumorSampleScat = sample
+    #    }
+    #}
+    #Array[SampleDescriptor] viterbiTumor = select_all(viterbiTumorSampleScat)
+
+
+    Array [SampleDescriptor] viterbiNormalSamples = select_all(flatten(viterbiNormal))
+    #this might also be a way of solving the upper problem of merging the optional normalMatched samples to a list of normal samples
+    #call common.SelectNormals as selectNormalSamples {
+    #    input:
+    #        normaleNames = select_all(uniqueNormals.outArray),
+    #        samples = sampleConfig.samples
+    #}
+
+    scatter (scatteredtargetsIdx in range(length(targetIntervals))) {
+        scatter(sample in viterbiSample){
+            IndexedFile sampleLofreqIndexedBam = select_first([sample.alignedReads])
+            scatter(normal in viterbiNormalSamples){
+                IndexedFile normalIndexedBam = select_first([normal.alignedReads])
+                if (normal.name != sample.name ){
+                    call lofreq.LoFreqSomatic as loFreqSomaticScat {
+                        input:
+                            lofreqModule=lofreqModule,
+                            pipelineUtilModule=pipelineUtilModule,
+                            picardModule=picardModule,
+                            inputNormalBam=normalIndexedBam.file,
+                            inputNormalBamIndex=normalIndexedBam.index,
+                            tumorSampleName=sample.name,
+                            normalSampleName=normal.name,
+                            inputTumorBam=sampleLofreqIndexedBam.file,
+                            inputTumorBamIndex=sampleLofreqIndexedBam.index,
+                            reference=reference,
+                            targetIntervalList=targetIntervals[scatteredtargetsIdx],
+                            outputVcfBasename='lofreq_sample_'+sample.name+'_norm_'+normal.name+'_scat'+scatteredtargetsIdx+'_',
+                            targetScatter = length(targetIntervals)
+                    }
+                    call util.Callerise as lofreqSampleCalleriseScat {
+                        input:
+                            pipelineUtilModule=pipelineUtilModule,
+                            inputVcf = loFreqSomaticScat.vcf,
+                            outputBase = 'lofreq_caller_sample_'+sample.name+'_norm_'+normal.name+'_scat'+scatteredtargetsIdx,
+                            caller="LoFreq_"
+                    }
+                    call bcftools.Norm as normSampleLofreqScat {
+                        input:
+                            bcftoolsModule=bcftoolsModule,
+                            reference=reference,
+                            inputVcf=lofreqSampleCalleriseScat.vcf,
+                            outputBasename ='lofreq_norm_sample_'+sample.name+'_norm_'+normal.name+'_scat'+scatteredtargetsIdx,
+                    }
+                    
+                    
+                }
+            }
+            
+            Array[File] normalisedTumorNormalSampleLofreqVcfs = select_all(normSampleLofreqScat.vcf)
+            Array[IndexedFile] normalisedTumorNormalSampleLofreqIdxVcfs = select_all(normSampleLofreqScat.vcfOut)
+            #merge all tumor normals into one for each tumor
+            call bcftools.Isec as mergeLoFreqNormalsScat {
+                input:
+                    bcftoolsModule=bcftoolsModule,
+                    inputVcfs=normalisedTumorNormalSampleLofreqVcfs,
+                    inputIdxVcfs=normalisedTumorNormalSampleLofreqIdxVcfs,
+                    outputBasename='Lofreq_variants_merged_normalisec_scat'+ scatteredtargetsIdx,
+                    minIntersect=length(select_all(normSampleLofreqScat.vcf)),
+            }
+            
+
+            #call gatk.HaplotypeCallerRecall as annotateLofreqNormalMergedLists {
+            #    input:
+            #        gatkModule=gatkModule,
+            #        reference=reference,
+            #        inputBams=gatherBams.link,
+            #        inputBais=gatherBais.link,
+            #        recallIndexedVcf=mergeLoFreqNormalsScat.vcfOut,
+            #        outputVcfBasename="lofreq_variants_haplotypecaller_anno_norm_merged_scat"+scatteredtargetsIdx,
+            #        targetScatter =  length(targetIntervals)
+            #}
+            #call bcftools.Norm as normaliseLofreqNormalsMerged {
+            #    input:
+            #        bcftoolsModule=bcftoolsModule,
+            #        reference=reference,
+            #        inputVcf=annotateLofreqNormalMergedLists.vcfOut.file,
+            #        outputBasename ="norm_merged_scat_"+scatteredtargetsIdx,
+            #}
+            #this could be better...
+            #call util.ReannotateVariants as annotateLofreqNormalsMerged {
+            #    input:
+            #        pipelineUtilModule=pipelineUtilModule,
+            #        combinedVariants=normaliseLofreqNormalsMerged.vcfOut,
+            #        inputVcfsFiles=select_all(normSampleLofreqScat.vcf),
+            #        inputVcfs=select_all(normSampleLofreqScat.vcfOut),
+            #        outputBasename='lofreq_annot_merged_normals_scat'+ scatteredtargetsIdx,
+            #}
+        }
+        Array[File] lofreqScatteredVcfs = select_all(flatten(normalisedTumorNormalSampleLofreqVcfs))
+        Array[IndexedFile] lofreqScatteredIdxVcfs = select_all(flatten(normalisedTumorNormalSampleLofreqIdxVcfs))
+        #merge all samples into one
+        call bcftools.Isec as mergeLoFreqVariants  {
+            input:
+                bcftoolsModule=bcftoolsModule,
+                inputVcfs=select_all(mergeLoFreqNormalsScat.vcf),
+                inputIdxVcfs=select_all(mergeLoFreqNormalsScat.vcfOut),
+                outputBasename='Lofreq_variants_merged_scat'+ scatteredtargetsIdx,
+                minIntersect=1,
+        }
+        
+        call gatk.HaplotypeCallerRecall as annotateLofreqMergedLists {
+            input:
+                gatkModule=gatkModule,
+                reference=reference,
+                inputBams=gatherBams.link,
+                inputBais=gatherBais.link,
+                recallIndexedVcf=mergeLoFreqVariants.vcfOut,
+                outputVcfBasename="lofreq_variants_haplotypecaller_anno_merged_scat"+scatteredtargetsIdx,
+                targetScatter =  length(targetIntervals)
+
+        }
+        call bcftools.Norm as normaliseLofreqMerged {
+            input:
+                bcftoolsModule=bcftoolsModule,
+                reference=reference,
+                inputVcf=annotateLofreqMergedLists.vcf,
+                outputBasename ="norm_merged_scat_"+scatteredtargetsIdx,
+        }
+        #this could be better...
+        call util.ReannotateVariants as annotateLofreqCallers {
+            input:
+                pipelineUtilModule=pipelineUtilModule,
+                combinedVariants=normaliseLofreqMerged.vcfOut,
+                inputVcfsFiles=flatten([lofreqScatteredVcfs,[annotateLofreqMergedLists.vcf]]),
+                inputVcfs=flatten([lofreqScatteredIdxVcfs,[annotateLofreqMergedLists.vcfOut]]),
+                outputBasename='lofreq_annot_merged_scat'+ scatteredtargetsIdx,
+        }
+        #filtering for normal samples
+        call bcftools.ViewSamples as lofreqNormals {
+            input:
+                bcftoolsModule=bcftoolsModule,
+                inputVcf = annotateLofreqCallers.vcf,
+                outputBasename = "freebayes_normals_scat_"+scatteredtargetsIdx,
+                samples=uniqueNormals.outArray
+        }
+        call util.AdFilter as lofreqFilterGermline {
+            input:
+                inputVariantsToFilter = annotateLofreqCallers.vcfOut,
+                inputVcfsFiles=[lofreqNormals.vcf],
+                inputVcfs=[lofreqNormals.vcfOut],
+                outputBasename='freebayes_normals_filt_scat_'+ scatteredtargetsIdx,
+        }
+    }
+    #calcing lofreq raw values pre merge would be nasty. 
+    call bcftools.Stats as lofreqStats {
+        input:
+            inputVcfs=lofreqFilterGermline.vcf,
+            inputIndexedVcfs=lofreqFilterGermline.vcfOut,
+            outputBasename="lofreq_stats",
+            bcftoolsModule=bcftoolsModule,
+    }
+    
+    output {
+        #output files of workflow
+        #needs to be debugged probably
+        Array[File] vcf = lofreqFilterGermline.vcf
+        Array[IndexedFile] idxVcf = lofreqFilterGermline.vcfOut
+        Array[File] bcftoolsStats = [lofreqStats.stats]
+    }
+
+    meta {
+        author: "MMTerpstra"
+        description: "This is the single samples bams to variants workflow."
+    }  
+}

--- a/workflows/bamsToSomaticMutectVariants.wdl
+++ b/workflows/bamsToSomaticMutectVariants.wdl
@@ -1,0 +1,185 @@
+version 1.0
+
+import "../structs.wdl" as structs
+import "../tasks/common.wdl" as common
+import "../tasks/trimgalore.wdl" as trimgalore
+import "../tasks/cutadapt.wdl" as cutadapt
+import "../tasks/fastqc.wdl" as fastqc
+import "../tasks/picard.wdl" as picard
+import "../tasks/fgbio.wdl" as fgbio
+import "../tasks/alignment.wdl" as align
+import "../tasks/gatk.wdl" as gatk
+import "../tasks/gatk_mutect2.wdl" as mutect
+import "../tasks/bcftools.wdl" as bcftools
+import "../tasks/freebayes.wdl" as freebayes
+import "../tasks/lofreq.wdl" as lofreq
+import "../tasks/pipeline-util.wdl" as util
+import "../tasks/ichorcna.wdl" as ichorcna
+import "../workflows/qc.wdl" as qc
+import "../workflows/bamsToGermlineVariants.wdl" as bamsToGermlineVariants
+
+
+workflow BamsToSomaticMutectVariants {
+    input {
+        String picardModule = "picard/2.26.10-Java-8-LTS"
+        String gatkModule = "GATK/4.2.4.1-Java-8-LTS"
+        String bcftoolsModule = "BCFtools/1.21-GCC-12.2.0"
+        String pipelineUtilModule = "pipeline-util/0.8.20-5-ga0a29bb-foss-2024a"
+        Reference reference
+        IndexedFile dbsnp
+        IndexedFile gnomadOnlyAfVcf
+        IndexedFile panelOfNormalsVcf
+        Array[IndexedFile] knownSites
+        File? sampleJson
+        SampleConfig? sampleConfigIn 
+        Array[File] targetIntervals
+    }
+    #This is a toggle to either use the sampleconfig in the input json or as separate file for conveniance 
+    SampleConfig sampleConfig = if (defined(sampleConfigIn)) then select_first([sampleConfigIn]) else read_json(select_first([sampleJson]))
+    
+    #Array[IndexedFile] sampleIndexedBams = sampleConfig[].samples.alignedReads
+    scatter (sample in sampleConfig.samples) {
+        IndexedFile sampleIndexedBam = select_first([sample.alignedReads])
+
+        call common.CreateLink as gatherBams {
+            input:
+                inputFile = sampleIndexedBam.file,
+                hardLink = true,
+                outputPath = select_first([sample.name])+ "_aligned_reads.bam",
+        }
+        call common.CreateLink as gatherBais {
+            input:
+                inputFile = sampleIndexedBam.index,
+                hardLink = true,
+                outputPath = select_first([sample.name])+ "_aligned_reads.bai",
+        }
+        if(defined(sample.normal)){
+            String sampleNormals = select_first([sample.normal])
+        }
+        String sampleNames = sample.name
+    }
+    #Array[String] sampleNames 
+    call common.UniqueArray as uniqueNormals {
+        input:
+            array = select_all(sampleNormals)
+    }
+    #this should be the best way of selecting normal samples 
+    #idk how it goes for wdl validation though
+    #Array[SampleDescriptor] normalSamples = []
+
+    #this works under the assumtion that at least one sampledescriptor is present for each normal name
+    
+    #better to post filter on normal samples 
+    #scatter (sample in viterbiSample) {
+    #    scatter(normalname in select_all(uniqueNormals.outArray)){
+    #        if (sample.name == normalname){
+    #            Boolean isTumor = false 
+    #        }
+    #    }
+    #    Boolean sampleIsTumor = select_first(flatten([isTumor,[true]]))
+    #    placeholder for dbugging
+    #    call common.UniqueArray as uniqueInputs {
+    #        input:
+    #            array = select_all(flatten([[sampleIsTumor],[isTumor,[true]]]))
+    #    }
+    #    if(sampleIsTumor){
+    #        SampleDescriptor viterbiTumorSampleScat = sample
+    #    }
+    #}
+    #Array[SampleDescriptor] viterbiTumor = select_all(viterbiTumorSampleScat)
+
+
+    #this might also be a way of solving the upper problem of merging the optional normalMatched samples to a list of normal samples
+    #call common.SelectNormals as selectNormalSamples {
+    #    input:
+    #        normaleNames = select_all(uniqueNormals.outArray),
+    #        samples = sampleConfig.samples
+    #}
+
+    scatter (scatteredtargetsIdx in range(length(targetIntervals))) {
+        call mutect.MuTect2JointCalling as mutect2 {
+            input:
+                gatkModule = gatkModule,
+                reference = reference,
+                germlineAfVcf = gnomadOnlyAfVcf,
+                panelOfNormalsVcf = panelOfNormalsVcf,
+                inputBams = gatherBams.link,
+                inputBamIndexes = gatherBais.link,
+                normals = uniqueNormals.outArray,
+                targetIntervalList = targetIntervals[scatteredtargetsIdx],
+                outputVcfBasename = "mutect_joint_calls_scat"+scatteredtargetsIdx,
+                targetScatter = length(targetIntervals)
+        }
+
+    }    
+    call mutect.LearnReadOrientationModel as learnReadOrientationModel {
+        input:
+            gatkModule = gatkModule,
+            f1r2TarGz = mutect2.f1r2TarGz,
+            outputArtifactPriorTableBasename = "read-orientation-model"
+    }
+    call mutect.MergeMutectStats as mergeMutectStats {
+        input:
+            gatkModule = gatkModule,
+            inputMutectStats = mutect2.stats,
+            outputMergedStats = "merged.stats"
+    }
+    scatter (scatteredtargetsIdx in range(length(targetIntervals))) {
+        #Mutect downstream
+        call mutect.FilterMutect as filterMutectCalls {
+            input:
+                gatkModule = gatkModule,
+                reference = reference,
+                inputSomaticVcf = mutect2.vcfOut[scatteredtargetsIdx],
+                stats = mergeMutectStats.stats,
+                artifactPriorsTarGz=learnReadOrientationModel.artifactpriortable,
+                outputVcfBasename="mutect_filterd_scat_"+scatteredtargetsIdx,
+                targetIntervalList = targetIntervals[scatteredtargetsIdx]
+        }
+        call util.Callerise as mutectScatCallerise {
+            input:
+                pipelineUtilModule=pipelineUtilModule,
+                inputVcf = filterMutectCalls.vcf,
+                outputBase = "mutect_tagged_scat_"+scatteredtargetsIdx,
+                caller="MuTect2_"
+        }
+        call bcftools.Norm as normaliseMutect {
+            input:
+                bcftoolsModule=bcftoolsModule,
+                reference=reference,
+                inputVcf=mutectScatCallerise.vcf,
+                outputBasename ="mutect_norm_scat_"+scatteredtargetsIdx,
+        }
+    }
+    
+    call bcftools.Stats as mutectRawStats {
+        input:
+            inputVcfs=mutect2.vcf,
+            inputIndexedVcfs=mutect2.vcfOut,
+            outputBasename="mutect_raw",
+            bcftoolsModule=bcftoolsModule,
+    }
+
+    call bcftools.Stats as mutectFilteredStats {
+        input:
+            inputVcfs=normaliseMutect.vcf,
+            inputIndexedVcfs=normaliseMutect.vcfOut,
+            outputBasename="mutect_filtered",
+            bcftoolsModule=bcftoolsModule,
+    }
+
+    #merge all regions
+
+    output {
+        #output files of workflow
+        #needs to be debugged probably
+        Array[File] vcf = normaliseMutect.vcf
+        Array[IndexedFile] idxVcf = normaliseMutect.vcfOut
+        Array[File] bcftoolsStats = [mutectRawStats.stats,mutectFilteredStats.stats]
+    }
+
+    meta {
+        author: "MMTerpstra"
+        description: "This is the single samples bams to variants workflow."
+    }  
+}

--- a/workflows/bamsToSomaticVariants.wdl
+++ b/workflows/bamsToSomaticVariants.wdl
@@ -1,0 +1,207 @@
+version 1.0
+
+import "../structs.wdl" as structs
+import "../tasks/common.wdl" as common
+import "../tasks/trimgalore.wdl" as trimgalore
+import "../tasks/cutadapt.wdl" as cutadapt
+import "../tasks/fastqc.wdl" as fastqc
+import "../tasks/picard.wdl" as picard
+import "../tasks/fgbio.wdl" as fgbio
+import "../tasks/alignment.wdl" as align
+import "../tasks/gatk.wdl" as gatk
+import "../tasks/gatk_mutect2.wdl" as mutect
+import "../tasks/bcftools.wdl" as bcftools
+import "../tasks/freebayes.wdl" as freebayes
+import "../tasks/lofreq.wdl" as lofreq
+import "../tasks/pipeline-util.wdl" as util
+import "../tasks/ichorcna.wdl" as ichorcna
+import "../workflows/qc.wdl" as qc
+import "../workflows/bamsToSomaticFreebayesVariants.wdl" as somaticFreebayes
+import "../workflows/bamsToSomaticMutectVariants.wdl" as somaticMutect
+import "../workflows/bamsToSomaticLofreqVariants.wdl" as somaticLofreq
+
+
+workflow BamsToSomaticVariants {
+    input {
+        String picardModule = "picard/2.26.10-Java-8-LTS"
+        String gatkModule = "GATK/4.2.4.1-Java-8-LTS"
+        String samtoolsModule = "SAMtools/1.15.1-GCC-11.3.0"
+        String bcftoolsModule = "BCFtools/1.21-GCC-12.2.0"
+        String freebayesModule = "freebayes/1.3.7-gfbf-2024a-R-4.4.2"
+        String pipelineUtilModule = "pipeline-util/0.8.20-5-ga0a29bb-foss-2024a"
+        String lofreqModule = "LoFreq/2.1.5-foss-2024a"
+        Reference reference
+        IndexedFile dbsnp
+        #IndexedFile cosmic
+        IndexedFile gnomadOnlyAfVcf
+        IndexedFile panelOfNormalsVcf
+        Array[IndexedFile] knownSites
+        File? funcotatorDsTar
+        #Array[SampleDescriptor] sample
+        File? sampleJson
+        SampleConfig? sampleConfigIn 
+        Array[File] targetIntervals
+    }
+    #This is a toggle to either use the sampleconfig in the input json or as separate file for conveniance 
+    SampleConfig sampleConfig = if (defined(sampleConfigIn)) then select_first([sampleConfigIn]) else read_json(select_first([sampleJson]))
+    
+    scatter (sample in sampleConfig.samples) {
+        IndexedFile sampleIndexedBam = select_first([sample.alignedReads])
+
+        call common.CreateLink as gatherBams {
+            input:
+                inputFile = sampleIndexedBam.file,
+                hardLink = true,
+                outputPath = select_first([sample.name])+ "_aligned_reads.bam",
+        }
+        call common.CreateLink as gatherBais {
+            input:
+                inputFile = sampleIndexedBam.index,
+                hardLink = true,
+                outputPath = select_first([sample.name])+ "_aligned_reads.bai",
+        }
+        if(defined(sample.normal)){
+            String sampleNormals = select_first([sample.normal])
+        }
+        String sampleNames = sample.name
+    }
+    
+    call somaticLofreq.BamsToSomaticLofreqVariants as somaticLofreq {
+        input:
+            picardModule = picardModule,
+            gatkModule = gatkModule,
+            samtoolsModule = samtoolsModule,
+            bcftoolsModule = bcftoolsModule,
+            pipelineUtilModule = pipelineUtilModule,
+            lofreqModule = lofreqModule,
+            reference=reference,
+            sampleConfigIn=sampleConfig,
+            targetIntervals=targetIntervals
+    }
+    call somaticFreebayes.BamsToSomaticFreebayesVariants as somaticFreebayes {
+        input:
+            bcftoolsModule = bcftoolsModule,
+            freebayesModule = freebayesModule, 
+            pipelineUtilModule = pipelineUtilModule,
+            reference=reference,
+            sampleConfigIn=sampleConfig,
+            targetIntervals=targetIntervals
+    }
+    call somaticMutect.BamsToSomaticMutectVariants as somaticMutect {
+        input:
+            picardModule = picardModule,
+            gatkModule = gatkModule,
+            bcftoolsModule = bcftoolsModule,
+            pipelineUtilModule = pipelineUtilModule,
+            reference = reference,
+            dbsnp = dbsnp,
+            gnomadOnlyAfVcf = gnomadOnlyAfVcf,
+            panelOfNormalsVcf = panelOfNormalsVcf,
+            knownSites = knownSites,
+            sampleConfigIn = sampleConfig, 
+            targetIntervals = targetIntervals
+    }
+    
+
+    scatter (scatteredtargetsIdx in range(length(targetIntervals))) {
+        #Mutect downstream
+        call bcftools.Isec as mergeVariantLists {
+            input:
+                bcftoolsModule=bcftoolsModule,
+                inputVcfs=select_all([somaticMutect.vcf[scatteredtargetsIdx],somaticFreebayes.vcf[scatteredtargetsIdx],somaticLofreq.vcf[scatteredtargetsIdx]]),
+                inputIdxVcfs=select_all([somaticMutect.idxVcf[scatteredtargetsIdx],somaticFreebayes.idxVcf[scatteredtargetsIdx],somaticLofreq.idxVcf[scatteredtargetsIdx]]),
+                outputBasename='variants_merged_scat'+ scatteredtargetsIdx,
+        }
+        call gatk.HaplotypeCallerRecall as annotateMergedLists {
+            input:
+                gatkModule=gatkModule,
+                reference=reference,
+                inputBams=gatherBams.link,
+                inputBais=gatherBais.link,
+                recallIndexedVcf=mergeVariantLists.idxVcf,
+                outputVcfBasename="variants_haplotypecaller_anno_merged_scat"+scatteredtargetsIdx,
+                targetScatter = length(targetIntervals)
+        }
+        call bcftools.Norm as normaliseMerged {
+            input:
+                bcftoolsModule=bcftoolsModule,
+                reference=reference,
+                inputVcf=annotateMergedLists.vcfOut.file,
+                outputBasename ="norm_merged_scat_"+scatteredtargetsIdx,
+        }
+        call util.ReannotateVariants as annotateCallers {
+            input:
+                pipelineUtilModule=pipelineUtilModule,
+                combinedVariants=normaliseMerged.vcfOut,
+                inputVcfsFiles=[somaticMutect.vcf[scatteredtargetsIdx],somaticFreebayes.vcf[scatteredtargetsIdx],somaticLofreq.vcf[scatteredtargetsIdx]],
+                inputVcfs=[somaticMutect.idxVcf[scatteredtargetsIdx],somaticFreebayes.idxVcf[scatteredtargetsIdx],somaticLofreq.idxVcf[scatteredtargetsIdx]],
+                outputBasename='annotCallers_merged_scat'+ scatteredtargetsIdx,
+        }
+        if(defined(funcotatorDsTar)){
+            call gatk.Funcotator as funcotateSomaticScattered {
+                input:
+                    inputVcf=annotateCallers.vcfOut,
+                    inputVcfFile=annotateCallers.vcf,
+                    reference=reference,
+                    funcotatorDsTar=select_first([funcotatorDsTar,reference.fasta]),
+                    outputVcfBasename="somatic_funcotated_scat"+ scatteredtargetsIdx,
+            }
+        }
+        File somaticScatteredVcf = select_first([funcotateSomaticScattered.vcf,annotateCallers.vcf])
+        IndexedFile somaticScatteredIdxVcf = select_first([funcotateSomaticScattered.vcfOut,annotateCallers.vcfOut])
+
+        #this function below is a band aid due to the level above the scatter not seeing the output as an array.
+        call common.CreateIndexedLink as linkSomaticScattered {
+            input:
+                inputFile=somaticScatteredVcf,
+                indexFile=somaticScatteredIdxVcf.index,
+                hardLink=true
+        }
+    }
+    
+    #merge all regions
+    call bcftools.Concat as mergeScatteredRegions {
+        input:
+            inputVcfs=linkSomaticScattered.file,
+            inputIndexedVcfs=linkSomaticScattered.out,
+            outputBasename="project_somatic",
+            bcftoolsModule=bcftoolsModule,
+    }
+
+    
+    call picard.SortVcfsIndexed as gatherMutect {
+        input:
+            picardModule = picardModule,
+            inputVcfs=somaticMutect.vcf,
+            outputPrefix="project_mutect2",
+            createIndex=true
+    }
+    call picard.SortVcfsIndexed as gatherFreebayes {
+        input:
+            picardModule = picardModule,
+            inputVcfs=somaticFreebayes.vcf,
+            outputPrefix="project_freebayes",
+            createIndex=true
+    }
+    call picard.SortVcfsIndexed as gatherLofreq {
+        input:
+            picardModule = picardModule,
+            inputVcfs=somaticLofreq.vcf,
+            outputPrefix="project_lofreq",
+            createIndex=true
+    }
+
+    output {
+        #output files of workflow
+        #needs to be debugged probably
+        Array[File] somaticScatVcf = linkSomaticScattered.file
+        Array[IndexedFile] somaticScatIdxVcf = linkSomaticScattered.out
+        IndexedFile somaticIdxVcf = mergeScatteredRegions.vcfOut
+        #Array[File] bcftoolsStats = [freebayesRawStats.stats,freebayesFilteredStats.stats,mutectFilteredStats.stats,mutectRawStats.stats,lofreqStats.stats]
+    }
+
+    meta {
+        author: "MMTerpstra"
+        description: "This is the single samples bams to variants workflow."
+    }  
+}

--- a/workflows/bamsToVariants.wdl
+++ b/workflows/bamsToVariants.wdl
@@ -12,10 +12,14 @@ import "../tasks/gatk.wdl" as gatk
 import "../tasks/gatk_mutect2.wdl" as mutect
 import "../tasks/bcftools.wdl" as bcftools
 import "../tasks/freebayes.wdl" as freebayes
+import "../tasks/lofreq.wdl" as lofreq
 import "../tasks/pipeline-util.wdl" as util
-
 import "../tasks/ichorcna.wdl" as ichorcna
 import "../workflows/qc.wdl" as qc
+import "../workflows/bamsToGermlineVariants.wdl" as bamsToGermlineVariants
+import "../workflows/bamsToSomaticVariants.wdl" as bamsToSomaticVariants
+
+
 
 workflow BamsToVariants {
     input {
@@ -25,19 +29,21 @@ workflow BamsToVariants {
         String bcftoolsModule = "BCFtools/1.21-GCC-12.2.0"
         String freebayesModule = "freebayes/1.3.7-gfbf-2024a-R-4.4.2"
         String pipelineUtilModule = "pipeline-util/0.8.20-5-ga0a29bb-foss-2024a"
+        String lofreqModule = "LoFreq/2.1.5-foss-2024a"
         Reference reference
         IndexedFile dbsnp
         #IndexedFile cosmic
         IndexedFile gnomadOnlyAfVcf
         IndexedFile panelOfNormalsVcf
         Array[IndexedFile] knownSites
+        File? funcotatorDsTar
         #Array[SampleDescriptor] sample
         File? sampleJson
         SampleConfig? sampleConfigIn 
         File targetIntervalList
         Int targetScatter
     }
-    #    SampleConfig sampleConfig = read_json(sampleJson)
+    #This is a toggle to either use the sampleconfig in the input json or as separate file for conveniance 
     SampleConfig sampleConfig = if (defined(sampleConfigIn)) then select_first([sampleConfigIn]) else read_json(select_first([sampleJson]))
 
     call picard.SplitAndPadIntervals as splitIntervals {
@@ -49,268 +55,41 @@ workflow BamsToVariants {
             padding = 200
     }
     
-    #Array[IndexedFile] sampleIndexedBams = sampleConfig[].samples.alignedReads
-    scatter (sample in sampleConfig.samples) {
-        IndexedFile sampleIndexedBam = select_first([sample.alignedReads])
-
-        call common.CreateLink as gatherBams {
-            input:
-                inputFile = sampleIndexedBam.file,
-                hardLink = true,
-                outputPath = select_first([sample.name])+ "_aligned_reads.bam",
-        }
-        call common.CreateLink as gatherBais {
-            input:
-                inputFile = sampleIndexedBam.index,
-                hardLink = true,
-                outputPath = select_first([sample.name])+ "_aligned_reads.bai",
-        }
-        if(defined(sample.normal)){
-            String sampleNormals = select_first([sample.normal])
-        }
-    }
-    call common.UniqueArray as uniqueNormals {
-        input:
-            array = select_all(sampleNormals)
-    }
-
-    scatter (scatteredtargetsIdx in range(length(splitIntervals.paddedScatteredIntervalList))) {
-        call mutect.MuTect2JointCalling as mutect2 {
-            input:
-                gatkModule = gatkModule,
-                reference = reference,
-                germlineAfVcf = gnomadOnlyAfVcf,
-                panelOfNormalsVcf = panelOfNormalsVcf,
-                inputBams = gatherBams.link,
-                inputBamIndexes = gatherBais.link,
-                normals = uniqueNormals.outArray,
-                targetIntervalList = splitIntervals.paddedScatteredIntervalList[scatteredtargetsIdx],
-                outputVcfBasename = "mutect_joint_calls_scat"+scatteredtargetsIdx
-        }
-        call freebayes.FreebayesSomatic as freebayesSomatic {
-            input:
-                freebayesModule = freebayesModule,
-                reference = reference,
-                inputBams = gatherBams.link,
-                inputBamIndexes = gatherBais.link,
-                targetIntervalList = splitIntervals.paddedScatteredIntervalList[scatteredtargetsIdx],
-                outputVcfBasename = "freebayes_joint_calls_scat"+scatteredtargetsIdx
-        }
-
-
-    }
-    call mutect.LearnReadOrientationModel as learnReadOrientationModel {
-        input:
-            gatkModule = gatkModule,
-            f1r2TarGz = mutect2.f1r2TarGz,
-            outputArtifactPriorTableBasename = "read-orientation-model"
-    }
-    call mutect.MergeMutectStats as mergeMutectStats {
-        input:
-            gatkModule = gatkModule,
-            inputMutectStats = mutect2.stats,
-            outputMergedStats = "merged.stats"
-    }
-    scatter (scatteredtargetsIdx in range(length(splitIntervals.paddedScatteredIntervalList))) {
-        #Mutect downstream
-        call mutect.FilterMutect as filterMutectCalls {
-            input:
-                gatkModule = gatkModule,
-                reference = reference,
-                inputSomaticVcf = mutect2.vcfOut[scatteredtargetsIdx],
-                stats = mergeMutectStats.stats,
-                artifactPriorsTarGz=learnReadOrientationModel.artifactpriortable,
-                outputVcfBasename="mutect_filterd_scat_"+scatteredtargetsIdx,
-                targetIntervalList = splitIntervals.paddedScatteredIntervalList[scatteredtargetsIdx]
-        }
-        call util.Callerise as mutectScatCallerise {
-            input:
-                pipelineUtilModule=pipelineUtilModule,
-                inputVcf = filterMutectCalls.vcf,
-                outputBase = "mutect_tagged_scat_"+scatteredtargetsIdx,
-                caller="MuTect2_"
-        }
-        call bcftools.Norm as normaliseMutect {
-            input:
-                bcftoolsModule=bcftoolsModule,
-                reference=reference,
-                inputVcf=mutectScatCallerise.vcf,
-                outputBasename ="mutect_norm_scat_"+scatteredtargetsIdx,
-        }
-        #freebayes downstream
-        call bcftools.ViewSamples as freebayesNormals {
-            input:
-                bcftoolsModule=bcftoolsModule,
-                inputVcf = freebayesSomatic.vcf[scatteredtargetsIdx],
-                outputBasename = "freebayes_normals_scat_"+scatteredtargetsIdx,
-                samples=uniqueNormals.outArray
-        }
-        call util.AdFilter as freebayesFilterGermline {
-            input:
-                inputVariantsToFilter = freebayesSomatic.vcfOut[scatteredtargetsIdx],
-                inputVcfsFiles=[freebayesNormals.vcf],
-                inputVcfs=[freebayesNormals.vcfOut],
-                outputBasename='freebayes_normals_filt_scat_'+ scatteredtargetsIdx,
-        }
-        #filterfreebayes?
-        call util.Callerise as freebayesScatCallerise {
-            input:
-                pipelineUtilModule=pipelineUtilModule,
-                inputVcf = freebayesFilterGermline.vcf,
-                outputBase = "freebayes_tagged_scat_"+scatteredtargetsIdx,
-                caller="freebayes_"
-        }
-        call bcftools.Norm as normaliseFreeBayes {
-            input:
-                bcftoolsModule=bcftoolsModule,
-                reference=reference,
-                inputVcf=freebayesScatCallerise.vcf,
-                outputBasename="freebayes_norm_scat_"+scatteredtargetsIdx,
-        }
-        #call gatk.GenomicsDBImport as importCallers {
-        #    input:
-        #        gatkModule = gatkModule,
-        #        reference = reference,
-        #        inputVcfsFiles=[normaliseFreeBayes.vcf,normaliseMutect.vcf],
-        #        inputVcfs=[normaliseFreeBayes.vcfOut,normaliseMutect.vcfOut],
-        #        outputBasename='variants_merged_scat'+ +scatteredtargetsIdx,
-        #        interval_list=splitIntervals.paddedScatteredIntervalList[scatteredtargetsIdx],
-        #}
-        #call gatk.SelectVariants as mergedVariantVcf {
-        #    input:
-        #        gatkModule = gatkModule,
-        #        reference = reference,
-        #        genomicsDbTar = importCallers.genomicsDbTar,
-        #        outputVcfBasename = 'merged_scat'+ +scatteredtargetsIdx,
-        #        
-        #
-        #}
-        call bcftools.Isec as mergeVariantLists {
-            input:
-                bcftoolsModule=bcftoolsModule,
-                inputVcfsFiles=[normaliseFreeBayes.vcf,normaliseMutect.vcf],
-                inputVcfs=[normaliseFreeBayes.vcfOut,normaliseMutect.vcfOut],
-                outputBasename='variants_merged_scat'+ scatteredtargetsIdx,
-        }
-        call freebayes.FreebayesRecall as annotateMergedLists {
-            input:
-                freebayesModule = freebayesModule,
-                reference = reference,
-                inputBams = gatherBams.link,
-                inputBamIndexes = gatherBais.link,
-                inputVariants=mergeVariantLists.vcfOut,
-                outputVcfBasename = "variants_freebayesanno_merged_scat"+scatteredtargetsIdx
-        }
-        call bcftools.Norm as normaliseMerged {
-            input:
-                bcftoolsModule=bcftoolsModule,
-                reference=reference,
-                inputVcf=annotateMergedLists.vcfOut.file,
-                outputBasename ="norm_merged_scat_"+scatteredtargetsIdx,
-        }
-        call util.ReannotateVariants as annotateCallers {
-            input:
-                pipelineUtilModule=pipelineUtilModule,
-                combinedVariants=normaliseMerged.vcfOut,
-                inputVcfsFiles=[normaliseFreeBayes.vcf,normaliseMutect.vcf],
-                inputVcfs=[normaliseFreeBayes.vcfOut,normaliseMutect.vcfOut],
-                outputBasename='annotCallers_merged_scat'+ scatteredtargetsIdx,
-        }
-
-    }
-    scatter (sample in sampleConfig.samples) {
-        IndexedFile sampleIndexedBamHc = select_first([sample.alignedReads])
-
-        scatter (scatteredtargetsIdx in range(length(splitIntervals.paddedScatteredIntervalList))) {
-        
-            #haplotypecallergvcf
-            call gatk.HaplotypeCallerGVcf as haplotypeCallerGvcf {
-                input:
-                    gatkModule = gatkModule,
-                    reference = reference,
-                    inputBam = sampleIndexedBamHc,
-                    outputVcfBasename = sample.name + ".idx_" + scatteredtargetsIdx,
-                    targetIntervalList = splitIntervals.paddedScatteredIntervalList[scatteredtargetsIdx]
-            }
-            
-            #mutect
-             
-            #if (defined(sample.control) ){
-            #    scatter (sampleControl in sampleConfig.samples) {
-            #        if(sample.control == sampleControl.name){
-            #            call mutect.MuTect2JointCalling as mutect2 {
-            #                input:
-            #                    gatkModule = gatkModule,
-            #                    reference = reference,
-            #                    germlineAfVcf = gnomadOnlyAfVcf,
-            #                    panelOfNormalsVcf = panelOfNormalsVcf,
-            #                    inputBams = sampleIndexedBam.file,
-            #                    inputBamIndexes = sampleIndexedBam.index,
-            #                    inputIntervalListFile = splitIntervals.paddedScatteredIntervalList[scatteredtargetsIdx]
-            #            }
-            #        }
-            #    }
-            #}
-            #Lofreq
-        }
-        #CombineGVCFs to create a single sample gvcf
-        call gatk.CombineGVCFs as gatherRegions {
-                input:
-                    gatkModule = gatkModule,
-                    reference = reference,
-                    inputGVcfs = haplotypeCallerGvcf.vcfOut,
-                    inputGVcfsFiles = haplotypeCallerGvcf.vcf,
-                    outputVcfBasename = sample.name + "_hcgvcf",
-        }
-        
-    }
-    call picard.SortVcfsIndexed as gatherMutect {
+    call bamsToSomaticVariants.BamsToSomaticVariants as somaticScattered {
         input:
             picardModule = picardModule,
-            inputVcfs=filterMutectCalls.vcf,
-            outputPrefix="project_mutect2",
-            createIndex=true
+            gatkModule = gatkModule,
+            samtoolsModule = samtoolsModule,
+            bcftoolsModule = bcftoolsModule,
+            freebayesModule = freebayesModule,
+            pipelineUtilModule = pipelineUtilModule,
+            lofreqModule = lofreqModule,
+            reference = reference,
+            dbsnp = dbsnp,
+            gnomadOnlyAfVcf = gnomadOnlyAfVcf,
+            panelOfNormalsVcf = panelOfNormalsVcf,
+            knownSites = knownSites,
+            sampleConfigIn = sampleConfig, 
+            targetIntervals = splitIntervals.paddedScatteredIntervalList
     }
-    call picard.SortVcfsIndexed as gatherFreebayes {
-        input:
-            picardModule = picardModule,
-            inputVcfs=freebayesSomatic.vcf,
-            outputPrefix="project_mutect2",
-            createIndex=true
-    }
-    #call bcftools.Index as indexMutect {
+
+         
+    #call bamsToGermlineVariants.BamsToGermlineVariants as germline {
     #    input:
-    #        bcftoolsModule = bcftoolsModule,
-    #        inputVcf = gatherMutect.outputVcf
-    #} 
-    #CombineGVCFs to create a single project gvcf
-    call gatk.CombineGVCFs as gatherHcSamples {
-        input:
-            gatkModule = gatkModule,
-            reference = reference,
-            inputGVcfs = gatherRegions.vcfOut,
-            inputGVcfsFiles = gatherRegions.vcf,
-            outputVcfBasename = "hcgvcf_allsamples",
-    }
-    #genotype gvcf
-    call gatk.GenotypeGVCFs as genotypeHcProjectGvcf {
-        input:
-            gatkModule = gatkModule,
-            reference = reference,
-            inputGVcf = gatherHcSamples.vcfOut,
-            inputGVcfsFile = gatherHcSamples.vcf,
-            outputVcfBasename = "hc_allsamples",
-    }
+    #        gatkModule = gatkModule,
+    #        reference = reference,
+    #        sampleConfigIn = sampleConfig,
+    #        targetIntervals = splitIntervals.paddedScatteredIntervalList
+    #}
+    #Array[IndexedFile] sampleIndexedBams = sampleConfig[].samples.alignedReads
+
     output {
         #output files of workflow
         #needs to be debugged probably
-        
-        #fastqtobam certain output
-        Array[IndexedFile] mutect2Vars = filterMutectCalls.vcfOut
-        #IndexedFile mutect2Vcf = indexMutect.vcfOut
-        IndexedFile haplotypecallergVcf = gatherHcSamples.vcfOut
-        IndexedFile haplotypecallerVcf = genotypeHcProjectGvcf.vcfOut
-        
+        IndexedFile somaticIdxVcf = somaticScattered.somaticIdxVcf
+        #IndexedFile haplotypecallerGVcf = germline.idxGvcf
+        #IndexedFile haplotypecallerIdxVcf = germline.idxVcf
+        #Array[File] bcftoolsStats = [freebayesRawStats.stats,freebayesFilteredStats.stats,mutectFilteredStats.stats,mutectRawStats.stats,lofreqStats.stats]
     }
 
     meta {


### PR DESCRIPTION
Large update splitting callers into separate workflows.
- 3 different somatic caller workflows:
   - Freebayes
   - Mutect2
   - Lofreq
Fixing workflow for exome size datasets.
Improving  walltime scaling with  targetscatter parameter for calling many regions
Many small fixes to tasks. 
 
 